### PR TITLE
Use `https` for test vocabulary

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang='en' prefix='rdfn: http://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
+<html lang='en' prefix='rdfn: https://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
 <head>
 <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
 <meta content='width=device-width, initial-scale=1.0' name='viewport'>

--- a/tests/manifest-urdna2015.ttl
+++ b/tests/manifest-urdna2015.ttl
@@ -15,7 +15,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix rdft: <http://www.w3.org/ns/rdftest#> .
-@prefix rdfn: <http://w3c.github.io/rdf-canon/tests/vocab#> .
+@prefix rdfn: <https://w3c.github.io/rdf-canon/tests/vocab#> .
 
 <manifest-urdna2015>  a mf:Manifest ;
 

--- a/tests/mk_manifest.rb
+++ b/tests/mk_manifest.rb
@@ -142,7 +142,7 @@ class Manifest
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix rdft: <http://www.w3.org/ns/rdftest#> .
-@prefix rdfn: <http://w3c.github.io/rdf-canon/tests/vocab#> .
+@prefix rdfn: <https://w3c.github.io/rdf-canon/tests/vocab#> .
 
 <manifest-#{variant}>  a mf:Manifest ;
 )

--- a/tests/mk_vocab.rb
+++ b/tests/mk_vocab.rb
@@ -24,7 +24,7 @@ File.open("vocab.jsonld", "w") do |f|
       template = File.read("vocab_template.haml")
       
       html = Haml::Engine.new(template, :format => :html5).render(self,
-        ontology:   compacted['@graph'].detect {|o| o['@id'] == "http://w3c.github.io/rdf-canon/tests/vocab#"},
+        ontology:   compacted['@graph'].detect {|o| o['@id'] == "https://w3c.github.io/rdf-canon/tests/vocab#"},
         classes:    compacted['@graph'].select {|o| o['@type'] == "rdfs:Class"}.sort_by {|o| o['rdfs:label']},
         properties: compacted['@graph'].select {|o| o['@type'] == "rdf:Property"}.sort_by {|o| o['rdfs:label']}
       )

--- a/tests/template.haml
+++ b/tests/template.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{lang: :en, prefix: "rdfn: http://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#"}
+%html{lang: :en, prefix: "rdfn: https://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#"}
   %head
     %meta{"http-equiv" => "Content-Type", content: "text/html;charset=utf-8"}
     %meta{name: "viewport", content: "width=device-width, initial-scale=1.0"}

--- a/tests/vocab.html
+++ b/tests/vocab.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang='en' prefix='rdfn: http://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
+<html lang='en' prefix='rdfn: https://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
 <head>
 <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
 <meta content='width=device-width, initial-scale=1.0' name='viewport'>
@@ -14,9 +14,9 @@
 RDF Dataset Canonicalization Test Vocabulary
 </title>
 </head>
-<body resource='http://w3c.github.io/rdf-canon/tests/vocab#' typeof='owl:Ontology'>
+<body resource='https://w3c.github.io/rdf-canon/tests/vocab#' typeof='owl:Ontology'>
 <meta property='dc:creator' value='Gregg Kellogg'>
-<link href='http://w3c.github.io/rdf-canon/tests/vocab#' property='dc:identifier'>
+<link href='https://w3c.github.io/rdf-canon/tests/vocab#' property='dc:identifier'>
 <p>
 <a href='http://www.w3.org/'>
 <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -28,7 +28,7 @@ RDF Dataset Canonicalization Test Vocabulary
 <a href="http://w3c.github.io/rdf-canon/tests/">RDF Dataset Canonicalization Test Cases</a> and associated test manifests.</p>
 <p>This vocabulary extends the <a href="http://www.w3.org/ns/rdftest#">RDF Test Vocabulary</a>
 and <a href="http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#">Test Manifest Vocabulary</a> with Normalization-specific tests.
-The URI of the vocabulary is <code>http://w3c.github.io/rdf-canon/tests/vocab#</code>
+The URI of the vocabulary is <code>https://w3c.github.io/rdf-canon/tests/vocab#</code>
 (abbreviated by <code>rdfn</code> in this document).
 <a href="vocab.ttl">Turtle</a> and <a href="vocab.jsonld">JSON-LD</a> versions of the vocabular are also available.
 The vocabulary is published by the <a href="https://www.w3.org/community/credentials/">W3C Credentials Community Group</a>.</p>

--- a/tests/vocab.jsonld
+++ b/tests/vocab.jsonld
@@ -3,7 +3,7 @@
     "dc": "http://purl.org/dc/elements/1.1/",
     "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfn": "http://w3c.github.io/rdf-canon/tests/vocab#",
+    "rdfn": "https://w3c.github.io/rdf-canon/tests/vocab#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "rdft": "http://www.w3.org/ns/rdftest#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
@@ -22,14 +22,14 @@
   },
   "@graph": [
     {
-      "@id": "http://w3c.github.io/rdf-canon/tests/vocab#",
+      "@id": "https://w3c.github.io/rdf-canon/tests/vocab#",
       "dc:title": "RDF Dataset Canonicalization Test Vocabulary",
       "dc:creator": "Gregg Kellogg",
       "dc:publisher": "W3C Credentials Community Group",
       "dc:description": "\n    This is a vocabulary document used to define classes and properties used in\n    [RDF Dataset Canonicalization Test Cases](http://w3c.github.io/rdf-canon/tests/) and associated test manifests.\n  ",
       "rdfs:comment": "This is a vocabulary document used to define classes and properties used in [RDF Dataset Canonicalization Test Cases](http://w3c.github.io/rdf-canon/tests/) and associated test manifests.",
       "dc:date": "2015-05-19",
-      "dc:identifier": "http://w3c.github.io/rdf-canon/tests/vocab#"
+      "dc:identifier": "https://w3c.github.io/rdf-canon/tests/vocab#"
     },
     {
       "@id": "rdfn:Test",

--- a/tests/vocab.ttl
+++ b/tests/vocab.ttl
@@ -2,11 +2,11 @@
 # This vocabulary defines classes an properties which extend
 # the test-manifest vocabulary at <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest>.
 
-@prefix :       <http://w3c.github.io/rdf-canon/tests/vocab#> .
+@prefix :       <https://w3c.github.io/rdf-canon/tests/vocab#> .
 @prefix dc:     <http://purl.org/dc/elements/1.1/> .
 @prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfn:   <http://w3c.github.io/rdf-canon/tests/vocab#> .
+@prefix rdfn:   <https://w3c.github.io/rdf-canon/tests/vocab#> .
 @prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix rdft:   <http://www.w3.org/ns/rdftest#> .
 @prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .

--- a/tests/vocab_context.jsonld
+++ b/tests/vocab_context.jsonld
@@ -3,7 +3,7 @@
     "dc": "http://purl.org/dc/elements/1.1/",
     "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfn": "http://w3c.github.io/rdf-canon/tests/vocab#",
+    "rdfn": "https://w3c.github.io/rdf-canon/tests/vocab#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "rdft": "http://www.w3.org/ns/rdftest#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",

--- a/tests/vocab_template.haml
+++ b/tests/vocab_template.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{lang: :en, prefix: "rdfn: http://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#"}
+%html{lang: :en, prefix: "rdfn: https://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#"}
   %head
     %meta{"http-equiv" => "Content-Type", content: "text/html;charset=utf-8"}
     %meta{name: "viewport", content: "width=device-width, initial-scale=1.0"}
@@ -24,7 +24,7 @@
 
         This vocabulary extends the [RDF Test Vocabulary](http://www.w3.org/ns/rdftest#)
         and [Test Manifest Vocabulary](http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#) with Normalization-specific tests.
-        The URI of the vocabulary is `http://w3c.github.io/rdf-canon/tests/vocab#`
+        The URI of the vocabulary is `https://w3c.github.io/rdf-canon/tests/vocab#`
         (abbreviated by `rdfn` in this document).
         [Turtle](vocab.ttl) and [JSON-LD](vocab.jsonld) versions of the vocabular are also available.
         The vocabulary is published by the [W3C Credentials Community Group](https://www.w3.org/community/credentials/).


### PR DESCRIPTION
Unless I misunderstood https://github.com/w3c/rdf-canon/pull/28#issuecomment-1310506672, all the places where our test vocabulary (`rdfn:`) appears as `http` URIs should be replaced with `https` URIs for consistency.