### PR TITLE
Use https for test vocabulary

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang='en' prefix='rdfn: https://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
+<html lang='en' prefix='rdfc: https://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
 <head>
 <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
 <meta content='width=device-width, initial-scale=1.0' name='viewport'>
@@ -109,13 +109,13 @@ manifest-urdna2015#test001:
 </a>
 <span about='manifest-urdna2015#test001' property='mf:name'>simple id</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test001' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test001' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -134,13 +134,13 @@ manifest-urdna2015#test002:
 </a>
 <span about='manifest-urdna2015#test002' property='mf:name'>duplicate property iri values</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test002' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test002' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -159,13 +159,13 @@ manifest-urdna2015#test003:
 </a>
 <span about='manifest-urdna2015#test003' property='mf:name'>bnode</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test003' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test003' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -184,13 +184,13 @@ manifest-urdna2015#test004:
 </a>
 <span about='manifest-urdna2015#test004' property='mf:name'>bnode plus embed w/subject</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test004' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test004' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -209,13 +209,13 @@ manifest-urdna2015#test005:
 </a>
 <span about='manifest-urdna2015#test005' property='mf:name'>bnode embed</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test005' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test005' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -234,13 +234,13 @@ manifest-urdna2015#test006:
 </a>
 <span about='manifest-urdna2015#test006' property='mf:name'>multiple rdf types</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test006' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test006' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -259,13 +259,13 @@ manifest-urdna2015#test007:
 </a>
 <span about='manifest-urdna2015#test007' property='mf:name'>coerce CURIE value</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test007' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test007' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -284,13 +284,13 @@ manifest-urdna2015#test008:
 </a>
 <span about='manifest-urdna2015#test008' property='mf:name'>single subject complex</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test008' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test008' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -309,13 +309,13 @@ manifest-urdna2015#test009:
 </a>
 <span about='manifest-urdna2015#test009' property='mf:name'>multiple subjects - complex</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test009' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test009' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -334,13 +334,13 @@ manifest-urdna2015#test010:
 </a>
 <span about='manifest-urdna2015#test010' property='mf:name'>type</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test010' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test010' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -359,13 +359,13 @@ manifest-urdna2015#test011:
 </a>
 <span about='manifest-urdna2015#test011' property='mf:name'>type-coerced type</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test011' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test011' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -384,13 +384,13 @@ manifest-urdna2015#test012:
 </a>
 <span about='manifest-urdna2015#test012' property='mf:name'>type-coerced type, remove duplicate reference</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test012' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test012' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -409,13 +409,13 @@ manifest-urdna2015#test013:
 </a>
 <span about='manifest-urdna2015#test013' property='mf:name'>type-coerced type, cycle</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test013' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test013' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -434,13 +434,13 @@ manifest-urdna2015#test014:
 </a>
 <span about='manifest-urdna2015#test014' property='mf:name'>check types</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test014' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test014' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -459,13 +459,13 @@ manifest-urdna2015#test015:
 </a>
 <span about='manifest-urdna2015#test015' property='mf:name'>top level context</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test015' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test015' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -484,13 +484,13 @@ manifest-urdna2015#test016:
 </a>
 <span about='manifest-urdna2015#test016' property='mf:name'>blank node - dual link - embed</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test016' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test016' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -509,13 +509,13 @@ manifest-urdna2015#test017:
 </a>
 <span about='manifest-urdna2015#test017' property='mf:name'>blank node - dual link - non-embed</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test017' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test017' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -534,13 +534,13 @@ manifest-urdna2015#test018:
 </a>
 <span about='manifest-urdna2015#test018' property='mf:name'>blank node - self link</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test018' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test018' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -559,13 +559,13 @@ manifest-urdna2015#test019:
 </a>
 <span about='manifest-urdna2015#test019' property='mf:name'>blank node - disjoint self links</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test019' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test019' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -584,13 +584,13 @@ manifest-urdna2015#test020:
 </a>
 <span about='manifest-urdna2015#test020' property='mf:name'>blank node - diamond</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test020' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test020' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -609,13 +609,13 @@ manifest-urdna2015#test021:
 </a>
 <span about='manifest-urdna2015#test021' property='mf:name'>blank node - circle of 2</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test021' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test021' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -634,13 +634,13 @@ manifest-urdna2015#test022:
 </a>
 <span about='manifest-urdna2015#test022' property='mf:name'>blank node - double circle of 2</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test022' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test022' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -659,13 +659,13 @@ manifest-urdna2015#test023:
 </a>
 <span about='manifest-urdna2015#test023' property='mf:name'>blank node - circle of 3</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test023' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test023' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -684,13 +684,13 @@ manifest-urdna2015#test024:
 </a>
 <span about='manifest-urdna2015#test024' property='mf:name'>blank node - double circle of 3 (1-2-3)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test024' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test024' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -709,13 +709,13 @@ manifest-urdna2015#test025:
 </a>
 <span about='manifest-urdna2015#test025' property='mf:name'>blank node - double circle of 3 (1-3-2)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test025' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test025' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -734,13 +734,13 @@ manifest-urdna2015#test026:
 </a>
 <span about='manifest-urdna2015#test026' property='mf:name'>blank node - double circle of 3 (2-1-3)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test026' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test026' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -759,13 +759,13 @@ manifest-urdna2015#test027:
 </a>
 <span about='manifest-urdna2015#test027' property='mf:name'>blank node - double circle of 3 (2-3-1)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test027' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test027' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -784,13 +784,13 @@ manifest-urdna2015#test028:
 </a>
 <span about='manifest-urdna2015#test028' property='mf:name'>blank node - double circle of 3 (3-2-1)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test028' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test028' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -809,13 +809,13 @@ manifest-urdna2015#test029:
 </a>
 <span about='manifest-urdna2015#test029' property='mf:name'>blank node - double circle of 3 (3-1-2)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test029' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test029' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -834,13 +834,13 @@ manifest-urdna2015#test030:
 </a>
 <span about='manifest-urdna2015#test030' property='mf:name'>blank node - point at circle of 3</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test030' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test030' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -859,13 +859,13 @@ manifest-urdna2015#test031:
 </a>
 <span about='manifest-urdna2015#test031' property='mf:name'>bnode (1)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test031' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test031' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -884,13 +884,13 @@ manifest-urdna2015#test032:
 </a>
 <span about='manifest-urdna2015#test032' property='mf:name'>bnode (2)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test032' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test032' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -909,13 +909,13 @@ manifest-urdna2015#test033:
 </a>
 <span about='manifest-urdna2015#test033' property='mf:name'>disjoint identical subgraphs (1)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test033' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test033' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -934,13 +934,13 @@ manifest-urdna2015#test034:
 </a>
 <span about='manifest-urdna2015#test034' property='mf:name'>disjoint identical subgraphs (2)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test034' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test034' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -959,13 +959,13 @@ manifest-urdna2015#test035:
 </a>
 <span about='manifest-urdna2015#test035' property='mf:name'>reordered w/strings (1)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test035' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test035' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -984,13 +984,13 @@ manifest-urdna2015#test036:
 </a>
 <span about='manifest-urdna2015#test036' property='mf:name'>reordered w/strings (2)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test036' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test036' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1009,13 +1009,13 @@ manifest-urdna2015#test037:
 </a>
 <span about='manifest-urdna2015#test037' property='mf:name'>reordered w/strings (3)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test037' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test037' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1034,13 +1034,13 @@ manifest-urdna2015#test038:
 </a>
 <span about='manifest-urdna2015#test038' property='mf:name'>reordered 4 bnodes, reordered 2 properties (1)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test038' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test038' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1059,13 +1059,13 @@ manifest-urdna2015#test039:
 </a>
 <span about='manifest-urdna2015#test039' property='mf:name'>reordered 4 bnodes, reordered 2 properties (2)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test039' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test039' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1084,13 +1084,13 @@ manifest-urdna2015#test040:
 </a>
 <span about='manifest-urdna2015#test040' property='mf:name'>reordered 6 bnodes (1)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test040' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test040' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1109,13 +1109,13 @@ manifest-urdna2015#test041:
 </a>
 <span about='manifest-urdna2015#test041' property='mf:name'>reordered 6 bnodes (2)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test041' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test041' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1134,13 +1134,13 @@ manifest-urdna2015#test042:
 </a>
 <span about='manifest-urdna2015#test042' property='mf:name'>reordered 6 bnodes (3)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test042' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test042' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1159,13 +1159,13 @@ manifest-urdna2015#test043:
 </a>
 <span about='manifest-urdna2015#test043' property='mf:name'>literal with language</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test043' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test043' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1184,13 +1184,13 @@ manifest-urdna2015#test044:
 </a>
 <span about='manifest-urdna2015#test044' property='mf:name'>evil (1)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test044' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test044' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1209,13 +1209,13 @@ manifest-urdna2015#test045:
 </a>
 <span about='manifest-urdna2015#test045' property='mf:name'>evil (2)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test045' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test045' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1234,13 +1234,13 @@ manifest-urdna2015#test046:
 </a>
 <span about='manifest-urdna2015#test046' property='mf:name'>evil (3)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test046' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test046' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1259,13 +1259,13 @@ manifest-urdna2015#test047:
 </a>
 <span about='manifest-urdna2015#test047' property='mf:name'>deep diff (1)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test047' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test047' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1284,13 +1284,13 @@ manifest-urdna2015#test048:
 </a>
 <span about='manifest-urdna2015#test048' property='mf:name'>deep diff (2)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test048' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test048' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1309,13 +1309,13 @@ manifest-urdna2015#test049:
 </a>
 <span about='manifest-urdna2015#test049' property='mf:name'>remove null</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test049' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test049' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1334,13 +1334,13 @@ manifest-urdna2015#test050:
 </a>
 <span about='manifest-urdna2015#test050' property='mf:name'>nulls</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test050' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test050' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1359,13 +1359,13 @@ manifest-urdna2015#test051:
 </a>
 <span about='manifest-urdna2015#test051' property='mf:name'>merging subjects</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test051' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test051' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1384,13 +1384,13 @@ manifest-urdna2015#test052:
 </a>
 <span about='manifest-urdna2015#test052' property='mf:name'>alias keywords</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test052' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test052' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1409,13 +1409,13 @@ manifest-urdna2015#test053:
 </a>
 <span about='manifest-urdna2015#test053' property='mf:name'>@list</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test053' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test053' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1434,13 +1434,13 @@ manifest-urdna2015#test054:
 </a>
 <span about='manifest-urdna2015#test054' property='mf:name'>t-graph</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test054' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test054' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1459,13 +1459,13 @@ manifest-urdna2015#test055:
 </a>
 <span about='manifest-urdna2015#test055' property='mf:name'>simple reorder (1)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test055' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test055' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1484,13 +1484,13 @@ manifest-urdna2015#test056:
 </a>
 <span about='manifest-urdna2015#test056' property='mf:name'>simple reorder (2)</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test056' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test056' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1509,13 +1509,13 @@ manifest-urdna2015#test057:
 </a>
 <span about='manifest-urdna2015#test057' property='mf:name'>unnamed graph</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test057' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test057' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1534,13 +1534,13 @@ manifest-urdna2015#test058:
 </a>
 <span about='manifest-urdna2015#test058' property='mf:name'>unnamed graph with blank node objects</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test058' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test058' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1559,13 +1559,13 @@ manifest-urdna2015#test059:
 </a>
 <span about='manifest-urdna2015#test059' property='mf:name'>n-quads parsing</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test059' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test059' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1584,13 +1584,13 @@ manifest-urdna2015#test060:
 </a>
 <span about='manifest-urdna2015#test060' property='mf:name'>n-quads escaping</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test060' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test060' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1609,13 +1609,13 @@ manifest-urdna2015#test061:
 </a>
 <span about='manifest-urdna2015#test061' property='mf:name'>same literal value with multiple languages</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test061' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test061' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>
@@ -1634,13 +1634,13 @@ manifest-urdna2015#test062:
 </a>
 <span about='manifest-urdna2015#test062' property='mf:name'>same literal value with multiple datatypes</span>
 </dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test062' typeof='rdfn:Urdna2015EvalTest'>
+<dd inlist property='mf:entry' resource='manifest-urdna2015#test062' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 
 </div>
 <dl class='test-detail'>
 <dt>type</dt>
-<dd>rdfn:Urdna2015EvalTest</dd>
+<dd>rdfc:Urdna2015EvalTest</dd>
 <dt>approval</dt>
 <dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
 <dt>action</dt>

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang='en' prefix='rdfn: http://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
+<html lang='en' prefix='rdfn: https://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
 <head>
 <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
 <meta content='width=device-width, initial-scale=1.0' name='viewport'>

--- a/tests/manifest-urdna2015.jsonld
+++ b/tests/manifest-urdna2015.jsonld
@@ -4,7 +4,7 @@
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
     "mq": "http://www.w3.org/2001/sw/DataAccess/tests/test-query#",
-    "rdfn": "https://w3c.github.io/rdf-canon/tests/vocab#",
+    "rdfc": "https://w3c.github.io/rdf-canon/tests/vocab#",
     "rdft": "http://www.w3.org/ns/rdftest#",
     "id": "@id",
     "type": "@type",
@@ -36,7 +36,7 @@
   "entries": [
     {
       "id": "manifest-urdna2015#test001",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "simple id",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -45,7 +45,7 @@
     },
     {
       "id": "manifest-urdna2015#test002",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "duplicate property iri values",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -54,7 +54,7 @@
     },
     {
       "id": "manifest-urdna2015#test003",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "bnode",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -63,7 +63,7 @@
     },
     {
       "id": "manifest-urdna2015#test004",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "bnode plus embed w/subject",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -72,7 +72,7 @@
     },
     {
       "id": "manifest-urdna2015#test005",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "bnode embed",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -81,7 +81,7 @@
     },
     {
       "id": "manifest-urdna2015#test006",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "multiple rdf types",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -90,7 +90,7 @@
     },
     {
       "id": "manifest-urdna2015#test007",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "coerce CURIE value",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -99,7 +99,7 @@
     },
     {
       "id": "manifest-urdna2015#test008",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "single subject complex",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -108,7 +108,7 @@
     },
     {
       "id": "manifest-urdna2015#test009",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "multiple subjects - complex",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -117,7 +117,7 @@
     },
     {
       "id": "manifest-urdna2015#test010",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "type",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -126,7 +126,7 @@
     },
     {
       "id": "manifest-urdna2015#test011",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "type-coerced type",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -135,7 +135,7 @@
     },
     {
       "id": "manifest-urdna2015#test012",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "type-coerced type, remove duplicate reference",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -144,7 +144,7 @@
     },
     {
       "id": "manifest-urdna2015#test013",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "type-coerced type, cycle",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -153,7 +153,7 @@
     },
     {
       "id": "manifest-urdna2015#test014",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "check types",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -162,7 +162,7 @@
     },
     {
       "id": "manifest-urdna2015#test015",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "top level context",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -171,7 +171,7 @@
     },
     {
       "id": "manifest-urdna2015#test016",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "blank node - dual link - embed",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -180,7 +180,7 @@
     },
     {
       "id": "manifest-urdna2015#test017",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "blank node - dual link - non-embed",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -189,7 +189,7 @@
     },
     {
       "id": "manifest-urdna2015#test018",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "blank node - self link",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -198,7 +198,7 @@
     },
     {
       "id": "manifest-urdna2015#test019",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "blank node - disjoint self links",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -207,7 +207,7 @@
     },
     {
       "id": "manifest-urdna2015#test020",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "blank node - diamond",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -216,7 +216,7 @@
     },
     {
       "id": "manifest-urdna2015#test021",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "blank node - circle of 2",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -225,7 +225,7 @@
     },
     {
       "id": "manifest-urdna2015#test022",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "blank node - double circle of 2",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -234,7 +234,7 @@
     },
     {
       "id": "manifest-urdna2015#test023",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "blank node - circle of 3",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -243,7 +243,7 @@
     },
     {
       "id": "manifest-urdna2015#test024",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "blank node - double circle of 3 (1-2-3)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -252,7 +252,7 @@
     },
     {
       "id": "manifest-urdna2015#test025",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "blank node - double circle of 3 (1-3-2)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -261,7 +261,7 @@
     },
     {
       "id": "manifest-urdna2015#test026",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "blank node - double circle of 3 (2-1-3)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -270,7 +270,7 @@
     },
     {
       "id": "manifest-urdna2015#test027",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "blank node - double circle of 3 (2-3-1)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -279,7 +279,7 @@
     },
     {
       "id": "manifest-urdna2015#test028",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "blank node - double circle of 3 (3-2-1)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -288,7 +288,7 @@
     },
     {
       "id": "manifest-urdna2015#test029",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "blank node - double circle of 3 (3-1-2)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -297,7 +297,7 @@
     },
     {
       "id": "manifest-urdna2015#test030",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "blank node - point at circle of 3",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -306,7 +306,7 @@
     },
     {
       "id": "manifest-urdna2015#test031",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "bnode (1)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -315,7 +315,7 @@
     },
     {
       "id": "manifest-urdna2015#test032",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "bnode (2)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -324,7 +324,7 @@
     },
     {
       "id": "manifest-urdna2015#test033",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "disjoint identical subgraphs (1)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -333,7 +333,7 @@
     },
     {
       "id": "manifest-urdna2015#test034",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "disjoint identical subgraphs (2)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -342,7 +342,7 @@
     },
     {
       "id": "manifest-urdna2015#test035",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "reordered w/strings (1)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -351,7 +351,7 @@
     },
     {
       "id": "manifest-urdna2015#test036",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "reordered w/strings (2)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -360,7 +360,7 @@
     },
     {
       "id": "manifest-urdna2015#test037",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "reordered w/strings (3)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -369,7 +369,7 @@
     },
     {
       "id": "manifest-urdna2015#test038",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "reordered 4 bnodes, reordered 2 properties (1)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -378,7 +378,7 @@
     },
     {
       "id": "manifest-urdna2015#test039",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "reordered 4 bnodes, reordered 2 properties (2)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -387,7 +387,7 @@
     },
     {
       "id": "manifest-urdna2015#test040",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "reordered 6 bnodes (1)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -396,7 +396,7 @@
     },
     {
       "id": "manifest-urdna2015#test041",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "reordered 6 bnodes (2)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -405,7 +405,7 @@
     },
     {
       "id": "manifest-urdna2015#test042",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "reordered 6 bnodes (3)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -414,7 +414,7 @@
     },
     {
       "id": "manifest-urdna2015#test043",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "literal with language",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -423,7 +423,7 @@
     },
     {
       "id": "manifest-urdna2015#test044",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "evil (1)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -432,7 +432,7 @@
     },
     {
       "id": "manifest-urdna2015#test045",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "evil (2)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -441,7 +441,7 @@
     },
     {
       "id": "manifest-urdna2015#test046",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "evil (3)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -450,7 +450,7 @@
     },
     {
       "id": "manifest-urdna2015#test047",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "deep diff (1)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -459,7 +459,7 @@
     },
     {
       "id": "manifest-urdna2015#test048",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "deep diff (2)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -468,7 +468,7 @@
     },
     {
       "id": "manifest-urdna2015#test049",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "remove null",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -477,7 +477,7 @@
     },
     {
       "id": "manifest-urdna2015#test050",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "nulls",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -486,7 +486,7 @@
     },
     {
       "id": "manifest-urdna2015#test051",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "merging subjects",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -495,7 +495,7 @@
     },
     {
       "id": "manifest-urdna2015#test052",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "alias keywords",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -504,7 +504,7 @@
     },
     {
       "id": "manifest-urdna2015#test053",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "@list",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -513,7 +513,7 @@
     },
     {
       "id": "manifest-urdna2015#test054",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "t-graph",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -522,7 +522,7 @@
     },
     {
       "id": "manifest-urdna2015#test055",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "simple reorder (1)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -531,7 +531,7 @@
     },
     {
       "id": "manifest-urdna2015#test056",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "simple reorder (2)",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -540,7 +540,7 @@
     },
     {
       "id": "manifest-urdna2015#test057",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "unnamed graph",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -549,7 +549,7 @@
     },
     {
       "id": "manifest-urdna2015#test058",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "unnamed graph with blank node objects",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -558,7 +558,7 @@
     },
     {
       "id": "manifest-urdna2015#test059",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "n-quads parsing",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -567,7 +567,7 @@
     },
     {
       "id": "manifest-urdna2015#test060",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "n-quads escaping",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -576,7 +576,7 @@
     },
     {
       "id": "manifest-urdna2015#test061",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "same literal value with multiple languages",
       "comment": null,
       "approval": "rdft:Proposed",
@@ -585,7 +585,7 @@
     },
     {
       "id": "manifest-urdna2015#test062",
-      "type": "rdfn:Urdna2015EvalTest",
+      "type": "rdfc:Urdna2015EvalTest",
       "name": "same literal value with multiple datatypes",
       "comment": null,
       "approval": "rdft:Proposed",

--- a/tests/manifest-urdna2015.ttl
+++ b/tests/manifest-urdna2015.ttl
@@ -8,14 +8,14 @@
 ## 3. http://www.w3.org/2004/10/27-testcases
 ##
 ## Test types
-## * rdfn:Urdna2015EvalTest  - Canonicalization using URDNA2015
+## * rdfc:Urdna2015EvalTest  - Canonicalization using URDNA2015
 
 @prefix : <manifest-urdna2015#> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfc: <https://w3c.github.io/rdf-canon/tests/vocab#> .
 @prefix rdft: <http://www.w3.org/ns/rdftest#> .
-@prefix rdfn: <https://w3c.github.io/rdf-canon/tests/vocab#> .
 
 <manifest-urdna2015>  a mf:Manifest ;
 
@@ -31,434 +31,434 @@
     :test061 :test062
   ) .
 
-:test001 a rdfn:Urdna2015EvalTest;
+:test001 a rdfc:Urdna2015EvalTest;
   mf:name "simple id";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test001-in.nq>;
   mf:result <urdna2015/test001-urdna2015.nq>;
   .
 
-:test002 a rdfn:Urdna2015EvalTest;
+:test002 a rdfc:Urdna2015EvalTest;
   mf:name "duplicate property iri values";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test002-in.nq>;
   mf:result <urdna2015/test002-urdna2015.nq>;
   .
 
-:test003 a rdfn:Urdna2015EvalTest;
+:test003 a rdfc:Urdna2015EvalTest;
   mf:name "bnode";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test003-in.nq>;
   mf:result <urdna2015/test003-urdna2015.nq>;
   .
 
-:test004 a rdfn:Urdna2015EvalTest;
+:test004 a rdfc:Urdna2015EvalTest;
   mf:name "bnode plus embed w/subject";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test004-in.nq>;
   mf:result <urdna2015/test004-urdna2015.nq>;
   .
 
-:test005 a rdfn:Urdna2015EvalTest;
+:test005 a rdfc:Urdna2015EvalTest;
   mf:name "bnode embed";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test005-in.nq>;
   mf:result <urdna2015/test005-urdna2015.nq>;
   .
 
-:test006 a rdfn:Urdna2015EvalTest;
+:test006 a rdfc:Urdna2015EvalTest;
   mf:name "multiple rdf types";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test006-in.nq>;
   mf:result <urdna2015/test006-urdna2015.nq>;
   .
 
-:test007 a rdfn:Urdna2015EvalTest;
+:test007 a rdfc:Urdna2015EvalTest;
   mf:name "coerce CURIE value";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test007-in.nq>;
   mf:result <urdna2015/test007-urdna2015.nq>;
   .
 
-:test008 a rdfn:Urdna2015EvalTest;
+:test008 a rdfc:Urdna2015EvalTest;
   mf:name "single subject complex";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test008-in.nq>;
   mf:result <urdna2015/test008-urdna2015.nq>;
   .
 
-:test009 a rdfn:Urdna2015EvalTest;
+:test009 a rdfc:Urdna2015EvalTest;
   mf:name "multiple subjects - complex";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test009-in.nq>;
   mf:result <urdna2015/test009-urdna2015.nq>;
   .
 
-:test010 a rdfn:Urdna2015EvalTest;
+:test010 a rdfc:Urdna2015EvalTest;
   mf:name "type";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test010-in.nq>;
   mf:result <urdna2015/test010-urdna2015.nq>;
   .
 
-:test011 a rdfn:Urdna2015EvalTest;
+:test011 a rdfc:Urdna2015EvalTest;
   mf:name "type-coerced type";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test011-in.nq>;
   mf:result <urdna2015/test011-urdna2015.nq>;
   .
 
-:test012 a rdfn:Urdna2015EvalTest;
+:test012 a rdfc:Urdna2015EvalTest;
   mf:name "type-coerced type, remove duplicate reference";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test012-in.nq>;
   mf:result <urdna2015/test012-urdna2015.nq>;
   .
 
-:test013 a rdfn:Urdna2015EvalTest;
+:test013 a rdfc:Urdna2015EvalTest;
   mf:name "type-coerced type, cycle";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test013-in.nq>;
   mf:result <urdna2015/test013-urdna2015.nq>;
   .
 
-:test014 a rdfn:Urdna2015EvalTest;
+:test014 a rdfc:Urdna2015EvalTest;
   mf:name "check types";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test014-in.nq>;
   mf:result <urdna2015/test014-urdna2015.nq>;
   .
 
-:test015 a rdfn:Urdna2015EvalTest;
+:test015 a rdfc:Urdna2015EvalTest;
   mf:name "top level context";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test015-in.nq>;
   mf:result <urdna2015/test015-urdna2015.nq>;
   .
 
-:test016 a rdfn:Urdna2015EvalTest;
+:test016 a rdfc:Urdna2015EvalTest;
   mf:name "blank node - dual link - embed";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test016-in.nq>;
   mf:result <urdna2015/test016-urdna2015.nq>;
   .
 
-:test017 a rdfn:Urdna2015EvalTest;
+:test017 a rdfc:Urdna2015EvalTest;
   mf:name "blank node - dual link - non-embed";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test017-in.nq>;
   mf:result <urdna2015/test017-urdna2015.nq>;
   .
 
-:test018 a rdfn:Urdna2015EvalTest;
+:test018 a rdfc:Urdna2015EvalTest;
   mf:name "blank node - self link";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test018-in.nq>;
   mf:result <urdna2015/test018-urdna2015.nq>;
   .
 
-:test019 a rdfn:Urdna2015EvalTest;
+:test019 a rdfc:Urdna2015EvalTest;
   mf:name "blank node - disjoint self links";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test019-in.nq>;
   mf:result <urdna2015/test019-urdna2015.nq>;
   .
 
-:test020 a rdfn:Urdna2015EvalTest;
+:test020 a rdfc:Urdna2015EvalTest;
   mf:name "blank node - diamond";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test020-in.nq>;
   mf:result <urdna2015/test020-urdna2015.nq>;
   .
 
-:test021 a rdfn:Urdna2015EvalTest;
+:test021 a rdfc:Urdna2015EvalTest;
   mf:name "blank node - circle of 2";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test021-in.nq>;
   mf:result <urdna2015/test021-urdna2015.nq>;
   .
 
-:test022 a rdfn:Urdna2015EvalTest;
+:test022 a rdfc:Urdna2015EvalTest;
   mf:name "blank node - double circle of 2";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test022-in.nq>;
   mf:result <urdna2015/test022-urdna2015.nq>;
   .
 
-:test023 a rdfn:Urdna2015EvalTest;
+:test023 a rdfc:Urdna2015EvalTest;
   mf:name "blank node - circle of 3";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test023-in.nq>;
   mf:result <urdna2015/test023-urdna2015.nq>;
   .
 
-:test024 a rdfn:Urdna2015EvalTest;
+:test024 a rdfc:Urdna2015EvalTest;
   mf:name "blank node - double circle of 3 (1-2-3)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test024-in.nq>;
   mf:result <urdna2015/test024-urdna2015.nq>;
   .
 
-:test025 a rdfn:Urdna2015EvalTest;
+:test025 a rdfc:Urdna2015EvalTest;
   mf:name "blank node - double circle of 3 (1-3-2)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test025-in.nq>;
   mf:result <urdna2015/test025-urdna2015.nq>;
   .
 
-:test026 a rdfn:Urdna2015EvalTest;
+:test026 a rdfc:Urdna2015EvalTest;
   mf:name "blank node - double circle of 3 (2-1-3)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test026-in.nq>;
   mf:result <urdna2015/test026-urdna2015.nq>;
   .
 
-:test027 a rdfn:Urdna2015EvalTest;
+:test027 a rdfc:Urdna2015EvalTest;
   mf:name "blank node - double circle of 3 (2-3-1)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test027-in.nq>;
   mf:result <urdna2015/test027-urdna2015.nq>;
   .
 
-:test028 a rdfn:Urdna2015EvalTest;
+:test028 a rdfc:Urdna2015EvalTest;
   mf:name "blank node - double circle of 3 (3-2-1)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test028-in.nq>;
   mf:result <urdna2015/test028-urdna2015.nq>;
   .
 
-:test029 a rdfn:Urdna2015EvalTest;
+:test029 a rdfc:Urdna2015EvalTest;
   mf:name "blank node - double circle of 3 (3-1-2)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test029-in.nq>;
   mf:result <urdna2015/test029-urdna2015.nq>;
   .
 
-:test030 a rdfn:Urdna2015EvalTest;
+:test030 a rdfc:Urdna2015EvalTest;
   mf:name "blank node - point at circle of 3";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test030-in.nq>;
   mf:result <urdna2015/test030-urdna2015.nq>;
   .
 
-:test031 a rdfn:Urdna2015EvalTest;
+:test031 a rdfc:Urdna2015EvalTest;
   mf:name "bnode (1)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test031-in.nq>;
   mf:result <urdna2015/test031-urdna2015.nq>;
   .
 
-:test032 a rdfn:Urdna2015EvalTest;
+:test032 a rdfc:Urdna2015EvalTest;
   mf:name "bnode (2)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test032-in.nq>;
   mf:result <urdna2015/test032-urdna2015.nq>;
   .
 
-:test033 a rdfn:Urdna2015EvalTest;
+:test033 a rdfc:Urdna2015EvalTest;
   mf:name "disjoint identical subgraphs (1)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test033-in.nq>;
   mf:result <urdna2015/test033-urdna2015.nq>;
   .
 
-:test034 a rdfn:Urdna2015EvalTest;
+:test034 a rdfc:Urdna2015EvalTest;
   mf:name "disjoint identical subgraphs (2)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test034-in.nq>;
   mf:result <urdna2015/test034-urdna2015.nq>;
   .
 
-:test035 a rdfn:Urdna2015EvalTest;
+:test035 a rdfc:Urdna2015EvalTest;
   mf:name "reordered w/strings (1)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test035-in.nq>;
   mf:result <urdna2015/test035-urdna2015.nq>;
   .
 
-:test036 a rdfn:Urdna2015EvalTest;
+:test036 a rdfc:Urdna2015EvalTest;
   mf:name "reordered w/strings (2)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test036-in.nq>;
   mf:result <urdna2015/test036-urdna2015.nq>;
   .
 
-:test037 a rdfn:Urdna2015EvalTest;
+:test037 a rdfc:Urdna2015EvalTest;
   mf:name "reordered w/strings (3)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test037-in.nq>;
   mf:result <urdna2015/test037-urdna2015.nq>;
   .
 
-:test038 a rdfn:Urdna2015EvalTest;
+:test038 a rdfc:Urdna2015EvalTest;
   mf:name "reordered 4 bnodes, reordered 2 properties (1)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test038-in.nq>;
   mf:result <urdna2015/test038-urdna2015.nq>;
   .
 
-:test039 a rdfn:Urdna2015EvalTest;
+:test039 a rdfc:Urdna2015EvalTest;
   mf:name "reordered 4 bnodes, reordered 2 properties (2)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test039-in.nq>;
   mf:result <urdna2015/test039-urdna2015.nq>;
   .
 
-:test040 a rdfn:Urdna2015EvalTest;
+:test040 a rdfc:Urdna2015EvalTest;
   mf:name "reordered 6 bnodes (1)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test040-in.nq>;
   mf:result <urdna2015/test040-urdna2015.nq>;
   .
 
-:test041 a rdfn:Urdna2015EvalTest;
+:test041 a rdfc:Urdna2015EvalTest;
   mf:name "reordered 6 bnodes (2)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test041-in.nq>;
   mf:result <urdna2015/test041-urdna2015.nq>;
   .
 
-:test042 a rdfn:Urdna2015EvalTest;
+:test042 a rdfc:Urdna2015EvalTest;
   mf:name "reordered 6 bnodes (3)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test042-in.nq>;
   mf:result <urdna2015/test042-urdna2015.nq>;
   .
 
-:test043 a rdfn:Urdna2015EvalTest;
+:test043 a rdfc:Urdna2015EvalTest;
   mf:name "literal with language";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test043-in.nq>;
   mf:result <urdna2015/test043-urdna2015.nq>;
   .
 
-:test044 a rdfn:Urdna2015EvalTest;
+:test044 a rdfc:Urdna2015EvalTest;
   mf:name "evil (1)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test044-in.nq>;
   mf:result <urdna2015/test044-urdna2015.nq>;
   .
 
-:test045 a rdfn:Urdna2015EvalTest;
+:test045 a rdfc:Urdna2015EvalTest;
   mf:name "evil (2)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test045-in.nq>;
   mf:result <urdna2015/test045-urdna2015.nq>;
   .
 
-:test046 a rdfn:Urdna2015EvalTest;
+:test046 a rdfc:Urdna2015EvalTest;
   mf:name "evil (3)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test046-in.nq>;
   mf:result <urdna2015/test046-urdna2015.nq>;
   .
 
-:test047 a rdfn:Urdna2015EvalTest;
+:test047 a rdfc:Urdna2015EvalTest;
   mf:name "deep diff (1)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test047-in.nq>;
   mf:result <urdna2015/test047-urdna2015.nq>;
   .
 
-:test048 a rdfn:Urdna2015EvalTest;
+:test048 a rdfc:Urdna2015EvalTest;
   mf:name "deep diff (2)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test048-in.nq>;
   mf:result <urdna2015/test048-urdna2015.nq>;
   .
 
-:test049 a rdfn:Urdna2015EvalTest;
+:test049 a rdfc:Urdna2015EvalTest;
   mf:name "remove null";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test049-in.nq>;
   mf:result <urdna2015/test049-urdna2015.nq>;
   .
 
-:test050 a rdfn:Urdna2015EvalTest;
+:test050 a rdfc:Urdna2015EvalTest;
   mf:name "nulls";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test050-in.nq>;
   mf:result <urdna2015/test050-urdna2015.nq>;
   .
 
-:test051 a rdfn:Urdna2015EvalTest;
+:test051 a rdfc:Urdna2015EvalTest;
   mf:name "merging subjects";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test051-in.nq>;
   mf:result <urdna2015/test051-urdna2015.nq>;
   .
 
-:test052 a rdfn:Urdna2015EvalTest;
+:test052 a rdfc:Urdna2015EvalTest;
   mf:name "alias keywords";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test052-in.nq>;
   mf:result <urdna2015/test052-urdna2015.nq>;
   .
 
-:test053 a rdfn:Urdna2015EvalTest;
+:test053 a rdfc:Urdna2015EvalTest;
   mf:name "@list";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test053-in.nq>;
   mf:result <urdna2015/test053-urdna2015.nq>;
   .
 
-:test054 a rdfn:Urdna2015EvalTest;
+:test054 a rdfc:Urdna2015EvalTest;
   mf:name "t-graph";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test054-in.nq>;
   mf:result <urdna2015/test054-urdna2015.nq>;
   .
 
-:test055 a rdfn:Urdna2015EvalTest;
+:test055 a rdfc:Urdna2015EvalTest;
   mf:name "simple reorder (1)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test055-in.nq>;
   mf:result <urdna2015/test055-urdna2015.nq>;
   .
 
-:test056 a rdfn:Urdna2015EvalTest;
+:test056 a rdfc:Urdna2015EvalTest;
   mf:name "simple reorder (2)";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test056-in.nq>;
   mf:result <urdna2015/test056-urdna2015.nq>;
   .
 
-:test057 a rdfn:Urdna2015EvalTest;
+:test057 a rdfc:Urdna2015EvalTest;
   mf:name "unnamed graph";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test057-in.nq>;
   mf:result <urdna2015/test057-urdna2015.nq>;
   .
 
-:test058 a rdfn:Urdna2015EvalTest;
+:test058 a rdfc:Urdna2015EvalTest;
   mf:name "unnamed graph with blank node objects";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test058-in.nq>;
   mf:result <urdna2015/test058-urdna2015.nq>;
   .
 
-:test059 a rdfn:Urdna2015EvalTest;
+:test059 a rdfc:Urdna2015EvalTest;
   mf:name "n-quads parsing";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test059-in.nq>;
   mf:result <urdna2015/test059-urdna2015.nq>;
   .
 
-:test060 a rdfn:Urdna2015EvalTest;
+:test060 a rdfc:Urdna2015EvalTest;
   mf:name "n-quads escaping";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test060-in.nq>;
   mf:result <urdna2015/test060-urdna2015.nq>;
   .
 
-:test061 a rdfn:Urdna2015EvalTest;
+:test061 a rdfc:Urdna2015EvalTest;
   mf:name "same literal value with multiple languages";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test061-in.nq>;
   mf:result <urdna2015/test061-urdna2015.nq>;
   .
 
-:test062 a rdfn:Urdna2015EvalTest;
+:test062 a rdfc:Urdna2015EvalTest;
   mf:name "same literal value with multiple datatypes";
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test062-in.nq>;

--- a/tests/manifest-urdna2015.ttl
+++ b/tests/manifest-urdna2015.ttl
@@ -15,7 +15,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix rdft: <http://www.w3.org/ns/rdftest#> .
-@prefix rdfn: <http://w3c.github.io/rdf-canon/tests/vocab#> .
+@prefix rdfn: <https://w3c.github.io/rdf-canon/tests/vocab#> .
 
 <manifest-urdna2015>  a mf:Manifest ;
 

--- a/tests/manifest.ttl
+++ b/tests/manifest.ttl
@@ -8,7 +8,7 @@
 ## 3. http://www.w3.org/2004/10/27-testcases
 ##
 ## Test types
-## * rdfn:Urdna2015EvalTest  - Canonicalization using URDNA2015
+## * rdfc:Urdna2015EvalTest  - Canonicalization using URDNA2015
 
 @prefix : <#> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/tests/mk_manifest.rb
+++ b/tests/mk_manifest.rb
@@ -59,8 +59,8 @@ class Manifest
 
   def test_class(test, variant)
     case variant.to_sym
-    when :urgna2012 then "rdfn:Urgna2012EvalTest"
-    when :urdna2015 then "rdfn:Urdna2015EvalTest"
+    when :urgna2012 then "rdfc:Urgna2012EvalTest"
+    when :urdna2015 then "rdfc:Urdna2015EvalTest"
     end
   end
 
@@ -70,7 +70,7 @@ class Manifest
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
       "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
       "mq": "http://www.w3.org/2001/sw/DataAccess/tests/test-query#",
-      "rdfn": "https://w3c.github.io/rdf-canon/tests/vocab#",
+      "rdfc": "https://w3c.github.io/rdf-canon/tests/vocab#",
       "rdft": "http://www.w3.org/ns/rdftest#",
       "id": "@id",
       "type": "@type",
@@ -135,14 +135,14 @@ class Manifest
 ## 3. http://www.w3.org/2004/10/27-testcases
 ##
 ## Test types
-## * rdfn:Urdna2015EvalTest  - Canonicalization using URDNA2015
+## * rdfc:Urdna2015EvalTest  - Canonicalization using URDNA2015
 
 @prefix : <manifest-#{variant}#> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdfc: <https://w3c.github.io/rdf-canon/tests/vocab#> .
 @prefix rdft: <http://www.w3.org/ns/rdftest#> .
-@prefix rdfn: <https://w3c.github.io/rdf-canon/tests/vocab#> .
 
 <manifest-#{variant}>  a mf:Manifest ;
 )

--- a/tests/mk_manifest.rb
+++ b/tests/mk_manifest.rb
@@ -142,7 +142,7 @@ class Manifest
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix rdft: <http://www.w3.org/ns/rdftest#> .
-@prefix rdfn: <http://w3c.github.io/rdf-canon/tests/vocab#> .
+@prefix rdfn: <https://w3c.github.io/rdf-canon/tests/vocab#> .
 
 <manifest-#{variant}>  a mf:Manifest ;
 )

--- a/tests/mk_vocab.rb
+++ b/tests/mk_vocab.rb
@@ -24,7 +24,7 @@ File.open("vocab.jsonld", "w") do |f|
       template = File.read("vocab_template.haml")
       
       html = Haml::Engine.new(template, :format => :html5).render(self,
-        ontology:   compacted['@graph'].detect {|o| o['@id'] == "http://w3c.github.io/rdf-canon/tests/vocab#"},
+        ontology:   compacted['@graph'].detect {|o| o['@id'] == "https://w3c.github.io/rdf-canon/tests/vocab#"},
         classes:    compacted['@graph'].select {|o| o['@type'] == "rdfs:Class"}.sort_by {|o| o['rdfs:label']},
         properties: compacted['@graph'].select {|o| o['@type'] == "rdf:Property"}.sort_by {|o| o['rdfs:label']}
       )

--- a/tests/template.haml
+++ b/tests/template.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{lang: :en, prefix: "rdfn: https://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#"}
+%html{lang: :en, prefix: "rdfc: https://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#"}
   %head
     %meta{"http-equiv" => "Content-Type", content: "text/html;charset=utf-8"}
     %meta{name: "viewport", content: "width=device-width, initial-scale=1.0"}

--- a/tests/template.haml
+++ b/tests/template.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{lang: :en, prefix: "rdfn: http://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#"}
+%html{lang: :en, prefix: "rdfn: https://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#"}
   %head
     %meta{"http-equiv" => "Content-Type", content: "text/html;charset=utf-8"}
     %meta{name: "viewport", content: "width=device-width, initial-scale=1.0"}

--- a/tests/vocab.html
+++ b/tests/vocab.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang='en' prefix='rdfn: https://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
+<html lang='en' prefix='rdfc: https://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
 <head>
 <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
 <meta content='width=device-width, initial-scale=1.0' name='viewport'>
@@ -29,7 +29,7 @@ RDF Dataset Canonicalization Test Vocabulary
 <p>This vocabulary extends the <a href="http://www.w3.org/ns/rdftest#">RDF Test Vocabulary</a>
 and <a href="http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#">Test Manifest Vocabulary</a> with Normalization-specific tests.
 The URI of the vocabulary is <code>https://w3c.github.io/rdf-canon/tests/vocab#</code>
-(abbreviated by <code>rdfn</code> in this document).
+(abbreviated by <code>rdfc</code> in this document).
 <a href="vocab.ttl">Turtle</a> and <a href="vocab.jsonld">JSON-LD</a> versions of the vocabular are also available.
 The vocabulary is published by the <a href="https://www.w3.org/community/credentials/">W3C Credentials Community Group</a>.</p>
 
@@ -40,8 +40,8 @@ The vocabulary is published by the <a href="https://www.w3.org/community/credent
 <section>
 <h3 id='classes'>Classes</h3>
 <dl>
-<dt about='rdfn:Test' property='rdfs:label' typeof='rdfs:Class'>rdfn:Test</dt>
-<dd about='rdfn:Test'>
+<dt about='rdfc:Test' property='rdfs:label' typeof='rdfs:Class'>rdfc:Test</dt>
+<dd about='rdfc:Test'>
 <em property='rdfs:label'>Superclass of all RDF Dataset Canonicalization tests</em>
 <span property='rdfs:comment'><p>All RDF Dataset Canonicalization tests have an input file referenced using <code>mf:action</code> and a result file referenced using <code>mf:result</code>. Results are compared as text where the result of running the test is serialized to canonical N-Quads, lexicographically-sorted.</p>
 </span>
@@ -59,8 +59,8 @@ subClassOf:
 </ul>
 </div>
 </dd>
-<dt about='rdfn:Urdna2015EvalTest' property='rdfs:label' typeof='rdfs:Class'>rdfn:Urdna2015EvalTest</dt>
-<dd about='rdfn:Urdna2015EvalTest'>
+<dt about='rdfc:Urdna2015EvalTest' property='rdfs:label' typeof='rdfs:Class'>rdfc:Urdna2015EvalTest</dt>
+<dd about='rdfc:Urdna2015EvalTest'>
 <em property='rdfs:label'>URDNA2015 Evaluation Test</em>
 <span property='rdfs:comment'><p>Canonicalization performed using the URDNA2015 algorithm.</p>
 </span>
@@ -68,7 +68,7 @@ subClassOf:
 <strong>
 subClassOf:
 </strong>
-<code property='rdfs:subClassOf' resource='rdfn:Test'>rdfn:Test</code>
+<code property='rdfs:subClassOf' resource='rdfc:Test'>rdfc:Test</code>
 </div>
 </dd>
 </dl>

--- a/tests/vocab.html
+++ b/tests/vocab.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang='en' prefix='rdfn: http://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
+<html lang='en' prefix='rdfn: https://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
 <head>
 <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
 <meta content='width=device-width, initial-scale=1.0' name='viewport'>
@@ -14,9 +14,9 @@
 RDF Dataset Canonicalization Test Vocabulary
 </title>
 </head>
-<body resource='http://w3c.github.io/rdf-canon/tests/vocab#' typeof='owl:Ontology'>
+<body resource='https://w3c.github.io/rdf-canon/tests/vocab#' typeof='owl:Ontology'>
 <meta property='dc:creator' value='Gregg Kellogg'>
-<link href='http://w3c.github.io/rdf-canon/tests/vocab#' property='dc:identifier'>
+<link href='https://w3c.github.io/rdf-canon/tests/vocab#' property='dc:identifier'>
 <p>
 <a href='http://www.w3.org/'>
 <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
@@ -28,7 +28,7 @@ RDF Dataset Canonicalization Test Vocabulary
 <a href="http://w3c.github.io/rdf-canon/tests/">RDF Dataset Canonicalization Test Cases</a> and associated test manifests.</p>
 <p>This vocabulary extends the <a href="http://www.w3.org/ns/rdftest#">RDF Test Vocabulary</a>
 and <a href="http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#">Test Manifest Vocabulary</a> with Normalization-specific tests.
-The URI of the vocabulary is <code>http://w3c.github.io/rdf-canon/tests/vocab#</code>
+The URI of the vocabulary is <code>https://w3c.github.io/rdf-canon/tests/vocab#</code>
 (abbreviated by <code>rdfn</code> in this document).
 <a href="vocab.ttl">Turtle</a> and <a href="vocab.jsonld">JSON-LD</a> versions of the vocabular are also available.
 The vocabulary is published by the <a href="https://www.w3.org/community/credentials/">W3C Credentials Community Group</a>.</p>

--- a/tests/vocab.jsonld
+++ b/tests/vocab.jsonld
@@ -3,7 +3,7 @@
     "dc": "http://purl.org/dc/elements/1.1/",
     "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfn": "http://w3c.github.io/rdf-canon/tests/vocab#",
+    "rdfn": "https://w3c.github.io/rdf-canon/tests/vocab#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "rdft": "http://www.w3.org/ns/rdftest#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
@@ -22,14 +22,14 @@
   },
   "@graph": [
     {
-      "@id": "http://w3c.github.io/rdf-canon/tests/vocab#",
+      "@id": "https://w3c.github.io/rdf-canon/tests/vocab#",
       "dc:title": "RDF Dataset Canonicalization Test Vocabulary",
       "dc:creator": "Gregg Kellogg",
       "dc:publisher": "W3C Credentials Community Group",
       "dc:description": "\n    This is a vocabulary document used to define classes and properties used in\n    [RDF Dataset Canonicalization Test Cases](http://w3c.github.io/rdf-canon/tests/) and associated test manifests.\n  ",
       "rdfs:comment": "This is a vocabulary document used to define classes and properties used in [RDF Dataset Canonicalization Test Cases](http://w3c.github.io/rdf-canon/tests/) and associated test manifests.",
       "dc:date": "2015-05-19",
-      "dc:identifier": "http://w3c.github.io/rdf-canon/tests/vocab#"
+      "dc:identifier": "https://w3c.github.io/rdf-canon/tests/vocab#"
     },
     {
       "@id": "rdfn:Test",

--- a/tests/vocab.jsonld
+++ b/tests/vocab.jsonld
@@ -3,7 +3,7 @@
     "dc": "http://purl.org/dc/elements/1.1/",
     "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfn": "https://w3c.github.io/rdf-canon/tests/vocab#",
+    "rdfc": "https://w3c.github.io/rdf-canon/tests/vocab#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "rdft": "http://www.w3.org/ns/rdftest#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
@@ -32,7 +32,7 @@
       "dc:identifier": "https://w3c.github.io/rdf-canon/tests/vocab#"
     },
     {
-      "@id": "rdfn:Test",
+      "@id": "rdfc:Test",
       "@type": "rdfs:Class",
       "rdfs:subClassOf": [
         "mf:ManifestEntry",
@@ -42,10 +42,10 @@
       "rdfs:comment": "All RDF Dataset Canonicalization tests have an input file referenced using `mf:action` and a result file referenced using `mf:result`. Results are compared as text where the result of running the test is serialized to canonical N-Quads, lexicographically-sorted."
     },
     {
-      "@id": "rdfn:Urdna2015EvalTest",
+      "@id": "rdfc:Urdna2015EvalTest",
       "@type": "rdfs:Class",
       "rdfs:label": "URDNA2015 Evaluation Test",
-      "rdfs:subClassOf": "rdfn:Test",
+      "rdfs:subClassOf": "rdfc:Test",
       "rdfs:comment": "Canonicalization performed using the URDNA2015 algorithm."
     }
   ]

--- a/tests/vocab.ttl
+++ b/tests/vocab.ttl
@@ -6,7 +6,7 @@
 @prefix dc:     <http://purl.org/dc/elements/1.1/> .
 @prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfn:   <https://w3c.github.io/rdf-canon/tests/vocab#> .
+@prefix rdfc:   <https://w3c.github.io/rdf-canon/tests/vocab#> .
 @prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix rdft:   <http://www.w3.org/ns/rdftest#> .
 @prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
@@ -23,7 +23,7 @@
     [RDF Dataset Canonicalization Test Cases](http://w3c.github.io/rdf-canon/tests/) and associated test manifests.
   """;
   dc:date          "2015-05-19";
-  dc:identifier    rdfn: .
+  dc:identifier    rdfc: .
 
 ## ---- Test Case Classes ---
 

--- a/tests/vocab.ttl
+++ b/tests/vocab.ttl
@@ -2,11 +2,11 @@
 # This vocabulary defines classes an properties which extend
 # the test-manifest vocabulary at <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest>.
 
-@prefix :       <http://w3c.github.io/rdf-canon/tests/vocab#> .
+@prefix :       <https://w3c.github.io/rdf-canon/tests/vocab#> .
 @prefix dc:     <http://purl.org/dc/elements/1.1/> .
 @prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfn:   <http://w3c.github.io/rdf-canon/tests/vocab#> .
+@prefix rdfn:   <https://w3c.github.io/rdf-canon/tests/vocab#> .
 @prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix rdft:   <http://www.w3.org/ns/rdftest#> .
 @prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .

--- a/tests/vocab_context.jsonld
+++ b/tests/vocab_context.jsonld
@@ -3,7 +3,7 @@
     "dc": "http://purl.org/dc/elements/1.1/",
     "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfn": "https://w3c.github.io/rdf-canon/tests/vocab#",
+    "rdfc": "https://w3c.github.io/rdf-canon/tests/vocab#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "rdft": "http://www.w3.org/ns/rdftest#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",

--- a/tests/vocab_context.jsonld
+++ b/tests/vocab_context.jsonld
@@ -3,7 +3,7 @@
     "dc": "http://purl.org/dc/elements/1.1/",
     "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfn": "http://w3c.github.io/rdf-canon/tests/vocab#",
+    "rdfn": "https://w3c.github.io/rdf-canon/tests/vocab#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "rdft": "http://www.w3.org/ns/rdftest#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",

--- a/tests/vocab_template.haml
+++ b/tests/vocab_template.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{lang: :en, prefix: "rdfn: http://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#"}
+%html{lang: :en, prefix: "rdfn: https://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#"}
   %head
     %meta{"http-equiv" => "Content-Type", content: "text/html;charset=utf-8"}
     %meta{name: "viewport", content: "width=device-width, initial-scale=1.0"}
@@ -24,7 +24,7 @@
 
         This vocabulary extends the [RDF Test Vocabulary](http://www.w3.org/ns/rdftest#)
         and [Test Manifest Vocabulary](http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#) with Normalization-specific tests.
-        The URI of the vocabulary is `http://w3c.github.io/rdf-canon/tests/vocab#`
+        The URI of the vocabulary is `https://w3c.github.io/rdf-canon/tests/vocab#`
         (abbreviated by `rdfn` in this document).
         [Turtle](vocab.ttl) and [JSON-LD](vocab.jsonld) versions of the vocabular are also available.
         The vocabulary is published by the [W3C Credentials Community Group](https://www.w3.org/community/credentials/).

--- a/tests/vocab_template.haml
+++ b/tests/vocab_template.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{lang: :en, prefix: "rdfn: https://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#"}
+%html{lang: :en, prefix: "rdfc: https://w3c.github.io/rdf-canon/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#"}
   %head
     %meta{"http-equiv" => "Content-Type", content: "text/html;charset=utf-8"}
     %meta{name: "viewport", content: "width=device-width, initial-scale=1.0"}
@@ -25,7 +25,7 @@
         This vocabulary extends the [RDF Test Vocabulary](http://www.w3.org/ns/rdftest#)
         and [Test Manifest Vocabulary](http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#) with Normalization-specific tests.
         The URI of the vocabulary is `https://w3c.github.io/rdf-canon/tests/vocab#`
-        (abbreviated by `rdfn` in this document).
+        (abbreviated by `rdfc` in this document).
         [Turtle](vocab.ttl) and [JSON-LD](vocab.jsonld) versions of the vocabular are also available.
         The vocabulary is published by the [W3C Credentials Community Group](https://www.w3.org/community/credentials/).
     %section


### PR DESCRIPTION
This replaces #30, and uses "rdfc" as the prefix for the test vocabulary.

Thanks @yamdan.