### PR TITLE
Removed the simple loop - issue 23

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1320,20 +1320,20 @@
 <section class="appendix informative" id="changes-from-fpwd">
   <h2>Changes since the First Public Working Draft of 24 November 2022</h2>
   <ul>
-    <li class="issue" data-number="23">
+    <li>
       <a href="#hash-1d-quads" class="sectionRef"></a>
       was simplified to remove the `simple` flag,
       which was unused in existing implementations.
-      The design of the algorithm was to use the
+      The original design of the algorithm was to use the
       assigned canonical <a>blank node identifier</a>,
       if available, instead of `_:a` or `_:z`,
       similar to how it is used in
       the related hash algorithm, but this text never made it into the spec
       before implementations moved forward.
-      Therefore, the hashes here
-      never change, making the loop based on the `simple`
-      flag that calls this algorithm unnecessary; it needs to only run
-      once.
+      Therefore, the hashes never change,
+      making the loop based on the `simple`
+      flag that calls this algorithm unnecessary.
+      See <a href="https://github.com/w3c/rdf-canon/issues/23">Issue 23</a> for the discussion.
     </li>
   </ul>
 </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -576,7 +576,6 @@
               <a>hash to blank nodes map</a>.</li>
           </ol>
         </li>
-        </li>
         <li id="ca-6">For each <var>hash</var> to <var>identifier list</var>
           <a data-cite="INFRA#map-entry">map entry</a> in
           <a>hash to blank nodes map</a>, <a>code point ordered</a> by
@@ -1337,7 +1336,6 @@
     </li>
   </ul>
 </section>
-<section id="issue-summary" class="appendix informative"></section>
 
 <section id="ack" class="appendix informative">
   <h2>Acknowledgements</h2>

--- a/spec/index.html
+++ b/spec/index.html
@@ -542,76 +542,66 @@
         <li id="ca-3">Create a list of non-normalized <a>blank node identifiers</a>
           <var>non-normalized identifiers</var> and populate it using the keys
           from the <a>blank node to quads map</a>.</li>
-        <li id="ca-4">Initialize <var>simple</var>, a boolean flag, to
-          <code>true</code>.</li>
-        <li id="ca-5">While <var>simple</var> is <code>true</code>,
-          issue canonical identifiers for <a>blank nodes</a>:
+        <li id="ca-4">Clear <a>hash to blank nodes map</a>.</li>
+        <li id="ca-5">For each <a>blank node identifier</a> <var>n</var> in <var>non-normalized identifiers</var>:
           <ol>
-            <li id="ca-5-1">Set <var>simple</var> to <code>false</code>.</li>
-            <li id="ca-5-2">Clear <a>hash to blank nodes map</a>.</li>
-            <li id="ca-5-3">For each <a>blank node identifier</a>
-              <var>n</var> in <var>non-normalized identifiers</var>:
-              <ol>
-                <li id="ca-5-3-1">Create a <a>hash</a>, <var>h<sub>f</sub>(n)</var>,
-                  for <var>n</var> according to the
-                  <a href="#hash-1d-quads">Hash First Degree Quads algorithm</a>.</li>
-                <li id="ca-5-3-2">Add <var>h<sub>f</sub>(n)</var> and <var>n</var> to
-                  <a>hash to blank nodes map</a>, including repetitions,
-                  creating a new entry if necessary.</li>
-              </ol>
-            </li>
-            <li id="ca-5-4">For each <var>hash</var> to <var>identifier list</var> mapping in
-              <a>hash to blank nodes map</a>, <a>code point ordered</a> by
-              <var>hash</var>:
-              <ol>
-                <li id="ca-5-4-1">If  <var>identifier list</var> has more than one entry,
-                  continue to the next mapping.</li>
-                <li id="ca-5-4-2">Use the
-                  <a href="#issue-identifier">Issue Identifier algorithm</a>,
-                  passing <a>canonical issuer</a> and the
-                  single <a>blank node identifier</a>, <var>identifier</var> in
-                  <var>identifier list</var> to issue a
-                  canonical replacement identifier for <var>identifier</var>.</li>
-                <li id="ca-5-4-3">Remove <var>identifier</var> from
-                  <var>non-normalized identifiers</var>.</li>
-                <li id="ca-5-4-4">Remove <var>hash</var> from the
-                  <a>hash to blank nodes map</a>.</li>
-                <li id="ca-5-4-5">Set <var>simple</var> to <code>true</code>.</li>
-              </ol>
-            </li>
+            <li id="ca-5-1">Create a <a>hash</a>, <var>h<sub>f</sub>(n)</var>,
+              for <var>n</var> according to the
+              <a href="#hash-1d-quads">Hash First Degree Quads algorithm</a>.</li>
+            <li id="ca-5-2">Add <var>h<sub>f</sub>(n)</var> and <var>n</var> to
+              <a>hash to blank nodes map</a>, including repetitions,
+              creating a new entry if necessary.</li>
           </ol>
         </li>
         <li id="ca-6">For each <var>hash</var> to <var>identifier list</var> mapping in
+          <a>hash to blank nodes map</a>, <a>code point ordered</a> by <var>hash</var>:
+          <ol>
+            <li id="ca-6-1">If  <var>identifier list</var> has more than one entry,
+              continue to the next mapping.</li>
+            <li id="ca-6-2">Use the
+              <a href="#issue-identifier">Issue Identifier algorithm</a>,
+              passing <a>canonical issuer</a> and the
+              single <a>blank node identifier</a>, <var>identifier</var> in
+              <var>identifier list</var> to issue a
+              canonical replacement identifier for <var>identifier</var>.</li>
+            <li id="ca-6-3">Remove <var>identifier</var> from
+              <var>non-normalized identifiers</var>.</li>
+            <li id="ca-6-4">Remove <var>hash</var> from the
+              <a>hash to blank nodes map</a>.</li>
+          </ol>
+        </li>
+        </li>
+        <li id="ca-7">For each <var>hash</var> to <var>identifier list</var> mapping in
           <a>hash to blank nodes map</a>, <a>code point ordered</a> by
           <var>hash</var>:
           <ol>
-            <li id="ca-6-1">Create <var>hash path list</var> where each item will be a result
+            <li id="ca-7-1">Create <var>hash path list</var> where each item will be a result
               of running the
               <a href="#hash-nd-quads">Hash N-Degree Quads algorithm</a>.</li>
-            <li id="ca-6-2">For each <a>blank node identifier</a>
+            <li id="ca-7-2">For each <a>blank node identifier</a>
               <var>n</var> in <var>identifier list</var>:
               <ol>
-                <li id="ca-6-2-1">If a canonical identifier has already been issued for
+                <li id="ca-7-2-1">If a canonical identifier has already been issued for
                   <var>n</var>, continue to the next
                   <a>blank node identifier</a>.</li>
-                <li id="ca-6-2-2">Create <var>temporary issuer</var>, an
+                <li id="ca-7-2-2">Create <var>temporary issuer</var>, an
                   <a>identifier issuer</a> initialized with the prefix
                   <code>_:b</code>.</li>
-                <li id="ca-6-2-3">Use the
+                <li id="ca-7-2-3">Use the
                   <a href="#issue-identifier">Issue Identifier algorithm</a>,
                   passing <var>temporary issuer</var> and <var>n</var>, to
                   issue a new temporary <a>blank node identifier</a> <var>b<sub>n</sub></var>
                   to <var>n</var>.</li>
-                <li id="ca-6-2-4">Run the
+                <li id="ca-7-2-4">Run the
                   <a href="#hash-nd-quads">Hash N-Degree Quads algorithm</a>,
                   passing <var>temporary issuer</var>, and append the
                   result to the <var>hash path list</var>.</li>
               </ol>
             </li>
-            <li id="ca-6-3">For each <var>result</var> in the <var>hash path list</var>,
+            <li id="ca-7-3">For each <var>result</var> in the <var>hash path list</var>,
               <a>code point ordered</a> by the <var>hash</var> in <var>result</var>:
               <ol>
-                <li id="ca-6-3-1">For each <a>blank node identifier</a>,
+                <li id="ca-7-3-1">For each <a>blank node identifier</a>,
                   <var>existing identifier</var>, that was issued a temporary
                   identifier by <var>identifier issuer</var> in <var>result</var>, issue
                   a canonical identifier, in the same order, using the
@@ -622,17 +612,17 @@
             </li>
           </ol>
         </li>
-        <li id="ca-7">For each <a>quad</a>, <var>q</var>, in <a>input dataset</a>:
+        <li id="ca-8">For each <a>quad</a>, <var>q</var>, in <a>input dataset</a>:
           <ol>
-            <li id="ca-7-1">Create a copy, <var>quad copy</var>, of <var>q</var> and replace any
+            <li id="ca-8-1">Create a copy, <var>quad copy</var>, of <var>q</var> and replace any
               existing <a>blank node identifier</a> <var>n</var> using the
               canonical identifiers previously issued
               by <a>canonical issuer</a>.</li>
-            <li id="ca-7-2">Add <var>quad copy</var> to the
+            <li id="ca-8-2">Add <var>quad copy</var> to the
               <a>normalized dataset</a>.</li>
           </ol>
         </li>
-        <li id="ca-8">Return the <a>normalized dataset</a>.</li>
+        <li id="ca-9">Return the <a>normalized dataset</a>.</li>
       </ol>
     </section>
   </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -86,9 +86,14 @@
   }
   a.externalDFN {border-bottom:  1px solid #99c; font-style: italic;}
 
-  code {
-    color:#c63501
+  code { color: #c63501; }
+
+  details {
+    background-color: rgb(245,245,245);
+    border-left: 0.3em solid rgb(200,200,200);
+    padding: 0.3em;
   }
+  summary {font-size: small; }
 </style>
 </head>
 
@@ -470,14 +475,6 @@
     <p class="ednote">Documenting the algorithm is a WIP, various steps will
       become more detailed in time.</p>
 
-    <p class="issue" data-number="23">See the issue in for the <a href="#hash-1d-quads" class="sectionRef"></a>. We should either remove the loop based on
-      <code>simple</code> here but indicate that the original design
-      of the algorithm was to have such a loop, or leave it but
-      inform implementers that it is safe to break after one iteration
-      of the loop (again, indicating why). A future version of this
-      algorithm should make the loop effectual.
-    </p>
-
     <section id="canon-algo-overview" class="informative">
       <h3>Overview</h3>
 
@@ -522,7 +519,15 @@
       <h3>Algorithm</h3>
 
       <ol>
-        <li id="ca-1">Create the <a>canonicalization state</a>.</li>
+        <li id="ca-1">Create the <a>canonicalization state</a>.
+          <details>
+            <summary>Explaination</summary>
+            <p>This has the effect of initializing the
+              <a>blank node to quads map</a>,
+              and the <a>hash to blank nodes map</a>,
+              as well as instantiating a new <a>canonical issuer</a>.</p>
+          </details>
+        </li>
         <li id="ca-2">For every <a>quad</a> <var>Q</var> in <a>input dataset</a>:
           <ol>
             <li id="ca-2-1">For each <a>blank node</a> that is a component of <var>Q</var>,
@@ -542,66 +547,65 @@
         <li id="ca-3">Create a list of non-normalized <a>blank node identifiers</a>
           <var>non-normalized identifiers</var> and populate it using the keys
           from the <a>blank node to quads map</a>.</li>
-        <li id="ca-4">Clear <a>hash to blank nodes map</a>.</li>
-        <li id="ca-5">For each <a>blank node identifier</a> <var>n</var> in <var>non-normalized identifiers</var>:
+        <li id="ca-4">For each <a>blank node identifier</a> <var>n</var> in <var>non-normalized identifiers</var>:
           <ol>
-            <li id="ca-5-1">Create a <a>hash</a>, <var>h<sub>f</sub>(n)</var>,
+            <li id="ca-4-1">Create a <a>hash</a>, <var>h<sub>f</sub>(n)</var>,
               for <var>n</var> according to the
               <a href="#hash-1d-quads">Hash First Degree Quads algorithm</a>.</li>
-            <li id="ca-5-2">Add <var>h<sub>f</sub>(n)</var> and <var>n</var> to
+            <li id="ca-4-2">Add <var>h<sub>f</sub>(n)</var> and <var>n</var> to
               <a>hash to blank nodes map</a>, including repetitions,
               creating a new entry if necessary.</li>
           </ol>
         </li>
-        <li id="ca-6">For each <var>hash</var> to <var>identifier list</var> mapping in
+        <li id="ca-5">For each <var>hash</var> to <var>identifier list</var> mapping in
           <a>hash to blank nodes map</a>, <a>code point ordered</a> by <var>hash</var>:
           <ol>
-            <li id="ca-6-1">If  <var>identifier list</var> has more than one entry,
+            <li id="ca-5-1">If <var>identifier list</var> has more than one entry,
               continue to the next mapping.</li>
-            <li id="ca-6-2">Use the
+            <li id="ca-5-2">Use the
               <a href="#issue-identifier">Issue Identifier algorithm</a>,
               passing <a>canonical issuer</a> and the
               single <a>blank node identifier</a>, <var>identifier</var> in
               <var>identifier list</var> to issue a
               canonical replacement identifier for <var>identifier</var>.</li>
-            <li id="ca-6-3">Remove <var>identifier</var> from
+            <li id="ca-5-3">Remove <var>identifier</var> from
               <var>non-normalized identifiers</var>.</li>
-            <li id="ca-6-4">Remove <var>hash</var> from the
+            <li id="ca-5-4">Remove <var>hash</var> from the
               <a>hash to blank nodes map</a>.</li>
           </ol>
         </li>
         </li>
-        <li id="ca-7">For each <var>hash</var> to <var>identifier list</var> mapping in
+        <li id="ca-6">For each <var>hash</var> to <var>identifier list</var> mapping in
           <a>hash to blank nodes map</a>, <a>code point ordered</a> by
           <var>hash</var>:
           <ol>
-            <li id="ca-7-1">Create <var>hash path list</var> where each item will be a result
+            <li id="ca-6-1">Create <var>hash path list</var> where each item will be a result
               of running the
               <a href="#hash-nd-quads">Hash N-Degree Quads algorithm</a>.</li>
-            <li id="ca-7-2">For each <a>blank node identifier</a>
+            <li id="ca-6-2">For each <a>blank node identifier</a>
               <var>n</var> in <var>identifier list</var>:
               <ol>
-                <li id="ca-7-2-1">If a canonical identifier has already been issued for
+                <li id="ca-6-2-1">If a canonical identifier has already been issued for
                   <var>n</var>, continue to the next
                   <a>blank node identifier</a>.</li>
-                <li id="ca-7-2-2">Create <var>temporary issuer</var>, an
+                <li id="ca-6-2-2">Create <var>temporary issuer</var>, an
                   <a>identifier issuer</a> initialized with the prefix
                   <code>_:b</code>.</li>
-                <li id="ca-7-2-3">Use the
+                <li id="ca-6-2-3">Use the
                   <a href="#issue-identifier">Issue Identifier algorithm</a>,
                   passing <var>temporary issuer</var> and <var>n</var>, to
                   issue a new temporary <a>blank node identifier</a> <var>b<sub>n</sub></var>
                   to <var>n</var>.</li>
-                <li id="ca-7-2-4">Run the
+                <li id="ca-6-2-4">Run the
                   <a href="#hash-nd-quads">Hash N-Degree Quads algorithm</a>,
                   passing <var>temporary issuer</var>, and append the
                   result to the <var>hash path list</var>.</li>
               </ol>
             </li>
-            <li id="ca-7-3">For each <var>result</var> in the <var>hash path list</var>,
+            <li id="ca-6-3">For each <var>result</var> in the <var>hash path list</var>,
               <a>code point ordered</a> by the <var>hash</var> in <var>result</var>:
               <ol>
-                <li id="ca-7-3-1">For each <a>blank node identifier</a>,
+                <li id="ca-6-3-1">For each <a>blank node identifier</a>,
                   <var>existing identifier</var>, that was issued a temporary
                   identifier by <var>identifier issuer</var> in <var>result</var>, issue
                   a canonical identifier, in the same order, using the
@@ -612,17 +616,17 @@
             </li>
           </ol>
         </li>
-        <li id="ca-8">For each <a>quad</a>, <var>q</var>, in <a>input dataset</a>:
+        <li id="ca-7">For each <a>quad</a>, <var>q</var>, in <a>input dataset</a>:
           <ol>
-            <li id="ca-8-1">Create a copy, <var>quad copy</var>, of <var>q</var> and replace any
+            <li id="ca-7-1">Create a copy, <var>quad copy</var>, of <var>q</var> and replace any
               existing <a>blank node identifier</a> <var>n</var> using the
               canonical identifiers previously issued
               by <a>canonical issuer</a>.</li>
-            <li id="ca-8-2">Add <var>quad copy</var> to the
+            <li id="ca-7-2">Add <var>quad copy</var> to the
               <a>normalized dataset</a>.</li>
           </ol>
         </li>
-        <li id="ca-9">Return the <a>normalized dataset</a>.</li>
+        <li id="ca-8">Return the <a>normalized dataset</a>.</li>
       </ol>
     </section>
   </section>
@@ -673,19 +677,6 @@
       Otherwise, a hash will be created for the blank node using
       the algorithm in <a href="#hash-nd-quads" class="sectionRef"></a>
       invoked via <a href="#canon-algorithm" class="sectionRef"></a>.</p>
-
-    <p class="issue" data-number="23">The result of this algorithm for a
-      particular blank node will always be the same. This is only true
-      because there was a typo in the spec that has now been implemented
-      by many implementations. The design of the algorithm was to use the
-      assigned canonical blank node identifier, if available, instead of
-      <code>_:a</code> or <code>_:z</code>, similar to how it is used in
-      the related hash algorithm, but this text never made it into the spec
-      before implementations moved forward. Therefore, the hashes here
-      never change, making the loop based on the <code>simple</code>
-      flag that calls this algorithm unnecessary; it needs to only run
-      once. A future version of this algorithm should correct this mistake.
-    </p>
 
     <section id="hash-1d-quads-overview" class="informative">
       <h3>Overview</h3>
@@ -1321,6 +1312,26 @@
   </ul>
 </section>
 
+<section class="appendix informative" id="changes-from-fpwd">
+  <h2>Changes since the First Public Working Draft of 24 November 2022</h2>
+  <ul>
+    <li class="issue" data-number="23">
+      <a href="#hash-1d-quads" class="sectionRef"></a>
+      was simplified to remove the `simple` flag,
+      which was unused in existing implementations.
+      The design of the algorithm was to use the
+      assigned canonical <a>blank node identifier</a>,
+      if available, instead of `_:a` or `_:z`,
+      similar to how it is used in
+      the related hash algorithm, but this text never made it into the spec
+      before implementations moved forward.
+      Therefore, the hashes here
+      never change, making the loop based on the `simple`
+      flag that calls this algorithm unnecessary; it needs to only run
+      once.
+    </li>
+  </ul>
+</section>
 <section id="issue-summary" class="appendix informative"></section>
 
 <section id="ack" class="appendix informative">

--- a/spec/index.html
+++ b/spec/index.html
@@ -398,11 +398,11 @@
 
     <dl>
       <dt><dfn>blank node to quads map</dfn></dt>
-      <dd>A data structure that maps a <a>blank node identifier</a> to
+      <dd>A <a data-cite="INFRA#ordered-map">map</a> that relates a <a>blank node identifier</a> to
         the <a>quads</a> in which they appear in the
         <a>input dataset</a>.</dd>
       <dt><dfn>hash to blank nodes map</dfn></dt>
-      <dd>A data structure that maps a <a>hash</a> to a list of
+      <dd>A <a data-cite="INFRA#ordered-map">map</a> that relates a <a>hash</a> to a list of
         <a>blank node identifiers</a>.</dd>
       <dt><dfn>canonical issuer</dfn></dt>
       <dd>An <a>identifier issuer</a>, initialized with the
@@ -531,9 +531,10 @@
         <li id="ca-2">For every <a>quad</a> <var>Q</var> in <a>input dataset</a>:
           <ol>
             <li id="ca-2-1">For each <a>blank node</a> that is a component of <var>Q</var>,
-              add a reference to the <var>Q</var> using the
-              <a>blank node identifier</a> in the
-              <a>blank node to quads map</a>,
+              add a reference to the <var>Q</var> from the
+              <a data-cite="INFRA#map-entry">map entry</a> for the
+              <a>blank node identifier</a> <var>identifier</var>
+              in the <a>blank node to quads map</a>,
               creating a new entry if necessary.
               <div class="issue" data-number="15">
                 It seems that <var>Q</var> must be normalized,
@@ -545,7 +546,7 @@
           </ol>
         </li>
         <li id="ca-3">Create a list of non-normalized <a>blank node identifiers</a>
-          <var>non-normalized identifiers</var> and populate it using the keys
+          <var>non-normalized identifiers</var> and populate it using the <a data-cite="INFRA#map-key">keys</a>
           from the <a>blank node to quads map</a>.</li>
         <li id="ca-4">For each <a>blank node identifier</a> <var>n</var> in <var>non-normalized identifiers</var>:
           <ol>
@@ -557,7 +558,8 @@
               creating a new entry if necessary.</li>
           </ol>
         </li>
-        <li id="ca-5">For each <var>hash</var> to <var>identifier list</var> mapping in
+        <li id="ca-5">For each <var>hash</var> to <var>identifier list</var>
+          <a data-cite="INFRA#map-entry">map entry</a> in
           <a>hash to blank nodes map</a>, <a>code point ordered</a> by <var>hash</var>:
           <ol>
             <li id="ca-5-1">If <var>identifier list</var> has more than one entry,
@@ -570,12 +572,13 @@
               canonical replacement identifier for <var>identifier</var>.</li>
             <li id="ca-5-3">Remove <var>identifier</var> from
               <var>non-normalized identifiers</var>.</li>
-            <li id="ca-5-4">Remove <var>hash</var> from the
+            <li id="ca-5-4">Remove the <a data-cite="INFRA#map-entry">map entry</a> for <var>hash</var> from the
               <a>hash to blank nodes map</a>.</li>
           </ol>
         </li>
         </li>
-        <li id="ca-6">For each <var>hash</var> to <var>identifier list</var> mapping in
+        <li id="ca-6">For each <var>hash</var> to <var>identifier list</var>
+          <a data-cite="INFRA#map-entry">map entry</a> in
           <a>hash to blank nodes map</a>, <a>code point ordered</a> by
           <var>hash</var>:
           <ol>
@@ -862,7 +865,8 @@
       <ol>
         <li id="h1d-1">Initialize <dfn>nquads</dfn> to an empty list. It will be
           used to store quads in [[N-Quads]] format.</li>
-        <li id="h1d-2">Get the list of <a>quads</a> <var>quads</var> associated with the
+        <li id="h1d-2">Get the list of <a>quads</a> <var>quads</var>
+          from the <a data-cite="INFRA#map-entry">map entry</a> for
           <a>reference blank node identifier</a> in the
           <a>blank node to quads map</a>.</li>
         <li id="h1d-3">For each <a>quad</a> <var>quad</var> in <var>quads</var>:
@@ -1128,8 +1132,9 @@
         <li id="hndq-1">Create a <var>hash to related blank nodes map</var> for storing
           hashes that identify related <a>blank nodes</a>.</li>
         <li id="hndq-2">Get a reference, <var>quads</var>, to the list of <a>quads</a>
-          in the <a>blank node to quads map</a> for the key
-          <var>identifier</var>.</li>
+          from the <a data-cite="INFRA#map-entry">map entry</a>
+          for <var>identifier</var>
+          in the <a>blank node to quads map</a>.</li>
         <li id="hndq-3">For each <var>quad</var> in <var>quads</var>:
           <ol>
             <li id="hndq-3-1">For each <var>component</var> in <var>quad</var>, where <var>component</var>


### PR DESCRIPTION
The core algorithm is now without the extra loop controlled by `simple`.

This is to fix #23 (if there is a consensus about this, of course).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/40.html" title="Last updated on Nov 23, 2022, 7:04 PM UTC (0dc13ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/40/22e6c14...0dc13ed.html" title="Last updated on Nov 23, 2022, 7:04 PM UTC (0dc13ed)">Diff</a>