### PR TITLE
Minor editorial knit: "canonical issuer' or just 'issuer'

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -2036,7 +2036,7 @@
                   recursively processed by this algorithm.</li>
                 <li id="hndq-5-4-4">For each <var>related</var> in <var>p</var>:
                   <ol>
-                    <li id="hndq-5-4-4-1">If a canonical identifier has been issued for
+                    <li id="hndq-5-4-4-1">If an identifier has been issued for
                       <var>related</var> by <var>issuer</var>, append the string <code>_:</code>, followed by 
                       <var>related</var>, to <var>path</var>.</li>
                     <li id="hndq-5-4-4-2">Otherwise:

--- a/spec/index.html
+++ b/spec/index.html
@@ -2038,7 +2038,14 @@
                   <ol>
                     <li id="hndq-5-4-4-1">If a canonical identifier has been issued for
                       <var>related</var> by <a>canonical issuer</a>, append the string <code>_:</code>, followed by 
-                      <var>related</var>, to <var>path</var>.</li>
+                      the canonical identifier for <var>related</var>, to <var>path</var>.
+                      <details><summary>Explanation</summary>
+                        <p>A canonical identifier may have been generated before calling this algorithm,
+                            if it was issued from an earlier call to <a href="#hash-1d-quads">Hash First Degree Quads algorithm</a>.
+                            There is no reason to recurse and apply the algorithm to any related blank node that has already been assigned a canonical identifier.
+                             Furthermore, using the canonical identifier also further distinguishes it from any temporary identifier, allowing for even greater efficiency in finding the chosen path.</p>
+                      </details>
+                    </li>
                     <li id="hndq-5-4-4-2">Otherwise:
                       <ol>
                         <li id="hndq-5-4-4-2-1">If <i>issuer copy</i> has not issued

--- a/spec/index.html
+++ b/spec/index.html
@@ -2036,8 +2036,8 @@
                   recursively processed by this algorithm.</li>
                 <li id="hndq-5-4-4">For each <var>related</var> in <var>p</var>:
                   <ol>
-                    <li id="hndq-5-4-4-1">If an identifier has been issued for
-                      <var>related</var> by <var>issuer</var>, append the string <code>_:</code>, followed by 
+                    <li id="hndq-5-4-4-1">If a canonical identifier has been issued for
+                      <var>related</var> by <a>canonical issuer</a>, append the string <code>_:</code>, followed by 
                       <var>related</var>, to <var>path</var>.</li>
                     <li id="hndq-5-4-4-2">Otherwise:
                       <ol>


### PR DESCRIPTION
In 5.4.4.1 of the Hash N-Degree Quads algorithm, it said

> If a canonical identifier has been issued…

~I propose to remove the term "canonical". It may mislead the reader (it misled me) to use the canonical issuer of the canonicalization state, which is (I believe) not the case here.~

The term "issuer" by itself misleads the reader (it misled me) to use the local, temporary issuer, rather than the canonical one.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/57.html" title="Last updated on Dec 16, 2022, 11:09 PM UTC (5fd2500)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/57/5b1e80f...5fd2500.html" title="Last updated on Dec 16, 2022, 11:09 PM UTC (5fd2500)">Diff</a>