### PR TITLE
Add missing _canonicalization state_ argument

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -499,16 +499,18 @@
 
   <section id="canon-algorithm" class="algorithm">
     <h2>Canonicalization Algorithm</h2>
-      <p class="ednote">At the time of writing, there are several open issues that will determine important details of the canonicalization algorithm.</p>
-      <div class="issue" data-number="4"></div>
-      <div class="issue" data-number="6"></div>
-      <div class="issue" data-number="7"></div>
-      <div class="issue" data-number="8"></div>
-      <div class="issue" data-number="10"></div>
-      <div class="issue" data-number="11"></div>
-      <div class="issue" data-number="16"></div>
-      <div class="issue" data-number="38"></div>
-      <div class="issue" data-number="41"></div>
+
+    <p class="ednote">At the time of writing, there are several open issues that will determine important details of the canonicalization algorithm.</p>
+    <div class="issue" data-number="4"></div>
+    <div class="issue" data-number="6"></div>
+    <div class="issue" data-number="7"></div>
+    <div class="issue" data-number="8"></div>
+    <div class="issue" data-number="10"></div>
+    <div class="issue" data-number="11"></div>
+    <div class="issue" data-number="16"></div>
+    <div class="issue" data-number="38"></div>
+    <div class="issue" data-number="41"></div>
+    <div class="issue" data-number="42"></div>
 
     <p>The canonicalization algorithm converts an <a>input dataset</a>
       into a <a>normalized dataset</a>. This algorithm will assign
@@ -2098,9 +2100,9 @@
                   </details>
                   <ol>
                     <li id="hndq-5-4-5-1">Set <var>result</var> to the result of recursively executing
-                      the
-                      <a href="#hash-nd-quads">Hash N-Degree Quads algorithm</a>,
-                      passing <var>related</var> for <var>identifier</var> and
+                      the <a href="#hash-nd-quads">Hash N-Degree Quads algorithm</a>,
+                      passing the <a>canonicalization state</a>,
+                      <var>related</var> for <var>identifier</var>, and
                       <var>issuer copy</var> for <var>path identifier issuer</var>.</li>
                     <li id="hndq-5-4-5-2">Use the
                       <a href="#issue-identifier">Issue Identifier algorithm</a>,


### PR DESCRIPTION
…to recursive call to Hash N-Degree Quads.

Fixes #47.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/61.html" title="Last updated on Dec 18, 2022, 7:18 PM UTC (662cd20)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/61/484e849...662cd20.html" title="Last updated on Dec 18, 2022, 7:18 PM UTC (662cd20)">Diff</a>