### PR TITLE
Add code for generating the Implementation Report

### DIFF
--- a/reports/.earl
+++ b/reports/.earl
@@ -1,0 +1,17 @@
+---
+:format: :json
+:manifest: manifests.nt
+:bibRef: ! '[[rdf-canon]]'
+:name: RDF Dataset Canonicalization 1.0
+:query: |
+  PREFIX mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+  PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+  SELECT ?uri ?testAction ?manUri
+  WHERE {
+    ?uri mf:action ?testAction .
+    OPTIONAL {
+      ?manUri a mf:Manifest; mf:entries ?lh .
+      ?lh rdf:first ?uri .
+    }
+  }

--- a/reports/README.md
+++ b/reports/README.md
@@ -29,7 +29,7 @@ Include an `earl:Assertion` for each test, referencing the test
   resource from the associated manifest and the test subject being
   reported upon. See the example below:
 
-```
+```turtle
 [ a               earl:Assertion ;
   earl:assertedBy <--your-developer-identifier--> ;
   earl:subject    <--your-software-identifier--> ;
@@ -48,7 +48,7 @@ The Test Subject should be defined as a `doap:Project`, including the name,
   and optionally including the
   project description and programming language. An example test subject description is the following:
 
-```
+```turtle
 <> foaf:primaryTopic        <--your-software-identifier--> ;
    dc:issued                "2016-12-26T10:18:04-08:00"^^xsd:dateTime ;
    foaf:maker               <--your-developer-identifier--> .
@@ -71,7 +71,7 @@ The Test Subject should be defined as a `doap:Project`, including the name,
 The software developer, either an organization or one or more individuals SHOULD be
   referenced from <code>doap:developer</code> using <a href="http://xmlns.com/foaf/spec">FOAF</a>. For example:</p>
 
-```
+```turtle
 <--your-developer-identifier--> 
    a             foaf:Person , 
                  earl:Assertor ;

--- a/reports/README.md
+++ b/reports/README.md
@@ -1,0 +1,16 @@
+This is a collection of individual
+[EARL reports](https://www.w3.org/TR/EARL10-Schema/) for
+test subjects claiming JSON-LD processor conformance.
+
+The consolidated report is saved to `index.html` generated
+using the
+[earl-report Ruby gem](https://rubygems.org/gems/earl-report).
+Run it as follows:
+
+```sh
+$ gem install earl-report
+$ rm -f manifests.nt && rake manifests.nt
+$ earl-report --format json -o earl.jsonld *.ttl
+$ earl-report --json --format ttl -o earl.ttl earl.jsonld
+$ earl-report --json --format html --template template.haml -o index.html earl.jsonld
+```

--- a/reports/README.md
+++ b/reports/README.md
@@ -14,3 +14,48 @@ $ earl-report --format json -o earl.jsonld *.ttl
 $ earl-report --json --format ttl -o earl.ttl earl.jsonld
 $ earl-report --json --format html --template template.haml -o index.html earl.jsonld
 ```
+
+
+<h2>Instructions for submitting implementation reports</h2>
+
+<p>Reports should be submitted in Turtle format to
+  <a href="mailto:public-rch-wg@w3.org">Public RCH WG</a> or via a Pull
+  Request to the <a href="https://github.com/w3c/rdf-canon/pulls">w3c/rdf-canon</a>.</p>
+
+<p>Tests should be run using the test manifests defined in the
+  <a href="#test-manifests">Test Manifests</a> Section.</p>
+
+<p>Include an <code>earl:Assertion</code> for each test, referencing the test
+  resource from the associated manifest and the test subject being
+  reported upon. See the example below:</p>
+
+<pre><code>  [ a earl:Assertion;&#x000A;    earl:assertedBy &lt;--your-developer-identifier--&gt;;&#x000A;    earl:subject &lt;--your-software-identifier--&gt;;&#x000A;    earl:test &lt;--uri-of-test-from-manifest&gt;;&#x000A;    earl:result [&#x000A;      a earl:TestResult;&#x000A;      earl:outcome earl:passed;&#x000A;      dc:date &quot;2023-01-25T10:18:04-08:00&quot;^^xsd:dateTime];&#x000A;    earl:mode earl:automatic ] .&#x000A;</code></pre>
+
+<p>The Test Subject should be defined as a <code>doap:Project</code>, including the name,
+  homepage and developer(s) of the software (see <a href="https://github.com/edumbill/doap/wiki">DOAP</a>). Optionally, including the
+  project description and programming language. An example test subject description is the following:</p>
+
+<pre><code>  &lt;&gt; foaf:primaryTopic &lt;--your-software-identifier--&gt; ;&#x000A;    dc:issued &quot;2016-12-26T10:18:04-08:00&quot;^^xsd:dateTime ;&#x000A;    foaf:maker &lt;--your-developer-identifier--&gt; .&#x000A;&#x000A;  &lt;--your-software-identifier--&gt; a doap:Project, earl:TestSubject, earl:Software ;&#x000A;    doap:name          &quot;My Cool RDF Canonicalizer&quot; ;&#x000A;    doap:release [&#x000A;      doap:name     &quot;--short name wih version number--&quot;;&#x000A;      doap:revision &quot;--Software version number--&quot; ;&#x000A;      doap:created  &quot;2020-02-19&quot;^^xsd:date;&#x000A;    ] ;&#x000A;    doap:developer     &lt;--your-developer-identifier--&gt; ;&#x000A;    doap:homepage      &lt;--your-software-homepace--&gt; ;&#x000A;    doap:description   &quot;--your-project-description--&quot;@en ;&#x000A;    doap:programming-language &quot;--your-implementation-language--&quot; .&#x000A;</code></pre>
+
+<p>The software developer, either an organization or one or more individuals SHOULD be
+  referenced from <code>doap:developer</code> using <a href="http://xmlns.com/foaf/spec">FOAF</a>. For example:</p>
+
+<pre><code>  &lt;--your-developer-identifier--&gt; a foaf:Person, earl:Assertor;&#x000A;    foaf:name &quot;--My Name--&quot;;&#x000A;    foaf:homepage &lt;--my homepage--&gt; .&#x000A;</code></pre>
+
+## Template files:
+
+* `template.haml` – Used by `earl-report` to generate `index.html`. Iterates over the generated `earl.jsonld` file along with built-in information about the working group.
+
+## Process files:
+
+* `Rakefile` – Builds `manifest.ttl` from the test suite. (could also add tasks to build `earl.jsonld`, `earl.ttl`, and `index.html`)
+
+## Generated files:
+
+* `earl.jsonld` – JSON-LD representation of the consolidated EARL submissions build by earl-report as described above.
+* `earl.ttl` – Turtle version of consolidated report, build from `earl.jsonld` by earl-report, as described above.
+* `index.html` – The processed implementation report, built by earl-report using `earl.jsonld`, as described above.
+
+## Submission files:
+
+Any files (other than `earl.ttl`) ending in `.ttl` are taken as individual EARL reports of test-suite conformance. For example `ruby-earl.ttl` is the report for [Ruby RDF::Normalize](https://github.com/ruby-rdf/rdf-normalize).

--- a/reports/README.md
+++ b/reports/README.md
@@ -16,31 +16,63 @@ $ earl-report --json --format html --template template.haml -o index.html earl.j
 ```
 
 
-<h2>Instructions for submitting implementation reports</h2>
+## Instructions for submitting implementation reports
 
-<p>Reports should be submitted in Turtle format to
+Reports should be submitted in Turtle format to
   <a href="mailto:public-rch-wg@w3.org">Public RCH WG</a> or via a Pull
-  Request to the <a href="https://github.com/w3c/rdf-canon/pulls">w3c/rdf-canon</a>.</p>
+  Request to the <a href="https://github.com/w3c/rdf-canon/pulls">w3c/rdf-canon</a>.
 
-<p>Tests should be run using the test manifests defined in the
-  <a href="#test-manifests">Test Manifests</a> Section.</p>
+Tests should be run using the test manifests defined in the
+  <a href="#test-manifests">Test Manifests</a> Section.
 
-<p>Include an <code>earl:Assertion</code> for each test, referencing the test
+Include an <code>earl:Assertion</code> for each test, referencing the test
   resource from the associated manifest and the test subject being
-  reported upon. See the example below:</p>
+  reported upon. See the example below:
 
-<pre><code>  [ a earl:Assertion;&#x000A;    earl:assertedBy &lt;--your-developer-identifier--&gt;;&#x000A;    earl:subject &lt;--your-software-identifier--&gt;;&#x000A;    earl:test &lt;--uri-of-test-from-manifest&gt;;&#x000A;    earl:result [&#x000A;      a earl:TestResult;&#x000A;      earl:outcome earl:passed;&#x000A;      dc:date &quot;2023-01-25T10:18:04-08:00&quot;^^xsd:dateTime];&#x000A;    earl:mode earl:automatic ] .&#x000A;</code></pre>
+```
+[ a earl:Assertion;
+    earl:assertedBy &lt;--your-developer-identifier--&gt;
+    earl:subject <--your-software-identifier-->;
+    earl:test <--uri-of-test-from-manifest>;
+    earl:result [
+      a earl:TestResult;
+        earl:outcome earl:passed;
+        dc:date "2023-01-25T10:18:04-08:00"^^xsd:dateTime];
+    earl:mode earl:automatic ] .
+```
 
-<p>The Test Subject should be defined as a <code>doap:Project</code>, including the name,
-  homepage and developer(s) of the software (see <a href="https://github.com/edumbill/doap/wiki">DOAP</a>). Optionally, including the
-  project description and programming language. An example test subject description is the following:</p>
+The Test Subject should be defined as a <code>doap:Project</code>, including the name,
+  homepage and developer(s) of the software
+  (see <a href="https://github.com/edumbill/doap/wiki">DOAP</a>).
+  Optionally, including the
+  project description and programming language. An example test subject description is the following:
 
-<pre><code>  &lt;&gt; foaf:primaryTopic &lt;--your-software-identifier--&gt; ;&#x000A;    dc:issued &quot;2016-12-26T10:18:04-08:00&quot;^^xsd:dateTime ;&#x000A;    foaf:maker &lt;--your-developer-identifier--&gt; .&#x000A;&#x000A;  &lt;--your-software-identifier--&gt; a doap:Project, earl:TestSubject, earl:Software ;&#x000A;    doap:name          &quot;My Cool RDF Canonicalizer&quot; ;&#x000A;    doap:release [&#x000A;      doap:name     &quot;--short name wih version number--&quot;;&#x000A;      doap:revision &quot;--Software version number--&quot; ;&#x000A;      doap:created  &quot;2020-02-19&quot;^^xsd:date;&#x000A;    ] ;&#x000A;    doap:developer     &lt;--your-developer-identifier--&gt; ;&#x000A;    doap:homepage      &lt;--your-software-homepace--&gt; ;&#x000A;    doap:description   &quot;--your-project-description--&quot;@en ;&#x000A;    doap:programming-language &quot;--your-implementation-language--&quot; .&#x000A;</code></pre>
+```
+<> foaf:primaryTopic <--your-software-identifier--> ;
+  dc:issued "2016-12-26T10:18:04-08:00"^^xsd:dateTime ;
+  foaf:maker <--your-developer-identifier--> .
 
-<p>The software developer, either an organization or one or more individuals SHOULD be
+<--your-software-identifier--> a doap:Project, earl:TestSubject, earl:Software ;
+  doap:name          "My Cool RDF Canonicalizer" ;
+  doap:release [
+    doap:name     "--short name wih version number--";
+    doap:revision "--Software version number--" ;
+    doap:created  "2020-02-19"^^xsd:date;
+  ] ;
+  doap:developer     <--your-developer-identifier--> ;
+  doap:homepage      <--your-software-homepace--> ;
+  doap:description   "--your-project-description--"@en ;
+  doap:programming-language "--your-implementation-language--" .
+```
+
+The software developer, either an organization or one or more individuals SHOULD be
   referenced from <code>doap:developer</code> using <a href="http://xmlns.com/foaf/spec">FOAF</a>. For example:</p>
 
-<pre><code>  &lt;--your-developer-identifier--&gt; a foaf:Person, earl:Assertor;&#x000A;    foaf:name &quot;--My Name--&quot;;&#x000A;    foaf:homepage &lt;--my homepage--&gt; .&#x000A;</code></pre>
+```
+<--your-developer-identifier--> a foaf:Person, earl:Assertor;
+  foaf:name "--My Name--";
+  foaf:homepage <--my homepage--> .
+```
 
 ## Template files:
 
@@ -50,12 +82,22 @@ $ earl-report --json --format html --template template.haml -o index.html earl.j
 
 * `Rakefile` – Builds `manifest.ttl` from the test suite. (could also add tasks to build `earl.jsonld`, `earl.ttl`, and `index.html`)
 
+Running the rake task and earl-report requires the installation of Ruby, and the following gems:
+
+* 'rdf-turtle'
+* 'json-ld'
+* 'haml'
+* 'kramdown'
+
 ## Generated files:
 
 * `earl.jsonld` – JSON-LD representation of the consolidated EARL submissions build by earl-report as described above.
 * `earl.ttl` – Turtle version of consolidated report, build from `earl.jsonld` by earl-report, as described above.
 * `index.html` – The processed implementation report, built by earl-report using `earl.jsonld`, as described above.
+* `manifest.nt` – Local cache of the test-suite manifest files, updated via `rake manifest.nt`.
 
 ## Submission files:
 
 Any files (other than `earl.ttl`) ending in `.ttl` are taken as individual EARL reports of test-suite conformance. For example `ruby-earl.ttl` is the report for [Ruby RDF::Normalize](https://github.com/ruby-rdf/rdf-normalize).
+
+As described above, each submission should have DOAP, FOAF, and individual Assertion elements.

--- a/reports/README.md
+++ b/reports/README.md
@@ -20,48 +20,51 @@ $ earl-report --json --format html --template template.haml -o index.html earl.j
 
 Reports should be submitted in Turtle format to
   <a href="mailto:public-rch-wg@w3.org">Public RCH WG</a> or via a Pull
-  Request to the <a href="https://github.com/w3c/rdf-canon/pulls">w3c/rdf-canon</a>.
+  Request to the [w3c/rdf-canon repository](https://github.com/w3c/rdf-canon/pulls).
 
 Tests should be run using the test manifests defined in the
-  <a href="#test-manifests">Test Manifests</a> Section.
+  [Test Manifests](#test-manifests) Section.
 
-Include an <code>earl:Assertion</code> for each test, referencing the test
+Include an `earl:Assertion` for each test, referencing the test
   resource from the associated manifest and the test subject being
   reported upon. See the example below:
 
 ```
-[ a earl:Assertion;
-    earl:assertedBy &lt;--your-developer-identifier--&gt;
-    earl:subject <--your-software-identifier-->;
-    earl:test <--uri-of-test-from-manifest>;
-    earl:result [
-      a earl:TestResult;
-        earl:outcome earl:passed;
-        dc:date "2023-01-25T10:18:04-08:00"^^xsd:dateTime];
-    earl:mode earl:automatic ] .
+[ a               earl:Assertion ;
+  earl:assertedBy <--your-developer-identifier--> ;
+  earl:subject    <--your-software-identifier--> ;
+  earl:test       <--uri-of-test-from-manifest> ;
+  earl:result     [ a            earl:TestResult ;
+                    earl:outcome earl:passed ;
+                    dc:date      "2023-01-25T10:18:04-08:00"^^xsd:dateTime 
+                  ] ;
+    earl:mode     earl:automatic 
+] .
 ```
 
-The Test Subject should be defined as a <code>doap:Project</code>, including the name,
-  homepage and developer(s) of the software
-  (see <a href="https://github.com/edumbill/doap/wiki">DOAP</a>).
-  Optionally, including the
+The Test Subject should be defined as a `doap:Project`, including the name,
+  homepage, and developer(s) of the software
+  (see [DOAP](https://github.com/edumbill/doap/wiki)),
+  and optionally including the
   project description and programming language. An example test subject description is the following:
 
 ```
-<> foaf:primaryTopic <--your-software-identifier--> ;
-  dc:issued "2016-12-26T10:18:04-08:00"^^xsd:dateTime ;
-  foaf:maker <--your-developer-identifier--> .
+<> foaf:primaryTopic        <--your-software-identifier--> ;
+   dc:issued                "2016-12-26T10:18:04-08:00"^^xsd:dateTime ;
+   foaf:maker               <--your-developer-identifier--> .
 
-<--your-software-identifier--> a doap:Project, earl:TestSubject, earl:Software ;
-  doap:name          "My Cool RDF Canonicalizer" ;
-  doap:release [
-    doap:name     "--short name wih version number--";
-    doap:revision "--Software version number--" ;
-    doap:created  "2020-02-19"^^xsd:date;
-  ] ;
-  doap:developer     <--your-developer-identifier--> ;
-  doap:homepage      <--your-software-homepace--> ;
-  doap:description   "--your-project-description--"@en ;
+<--your-software-identifier--> 
+   a                        doap:Project , 
+                            earl:TestSubject , 
+                            earl:Software ;
+  doap:name                 "My Cool RDF Canonicalizer" ;
+  doap:release              [ doap:name     "--short name wih version number--" ;
+                              doap:revision "--Software version number--" ;
+                              doap:created  "2020-02-19"^^xsd:date ;
+                            ] ;
+  doap:developer            <--your-developer-identifier--> ;
+  doap:homepage             <--your-software-homepace--> ;
+  doap:description          "--your-project-description--"@en ;
   doap:programming-language "--your-implementation-language--" .
 ```
 
@@ -69,9 +72,11 @@ The software developer, either an organization or one or more individuals SHOULD
   referenced from <code>doap:developer</code> using <a href="http://xmlns.com/foaf/spec">FOAF</a>. For example:</p>
 
 ```
-<--your-developer-identifier--> a foaf:Person, earl:Assertor;
-  foaf:name "--My Name--";
-  foaf:homepage <--my homepage--> .
+<--your-developer-identifier--> 
+   a             foaf:Person , 
+                 earl:Assertor ;
+   foaf:name     "--My Name--" ;
+   foaf:homepage <--my homepage--> .
 ```
 
 ## Template files:
@@ -80,14 +85,14 @@ The software developer, either an organization or one or more individuals SHOULD
 
 ## Process files:
 
-* `Rakefile` – Builds `manifest.ttl` from the test suite. (could also add tasks to build `earl.jsonld`, `earl.ttl`, and `index.html`)
+* `Rakefile` – Builds `manifest.ttl` from the test suite. (Tasks could also be added to build `earl.jsonld`, `earl.ttl`, and/or `index.html`)
 
-Running the rake task and earl-report requires the installation of Ruby, and the following gems:
+Running the `rake` task and `earl-report` requires installation of Ruby, and the following gems:
 
-* 'rdf-turtle'
-* 'json-ld'
-* 'haml'
-* 'kramdown'
+* `rdf-turtle`
+* `json-ld`
+* `haml`
+* `kramdown`
 
 ## Generated files:
 
@@ -98,6 +103,6 @@ Running the rake task and earl-report requires the installation of Ruby, and the
 
 ## Submission files:
 
-Any files (other than `earl.ttl`) ending in `.ttl` are taken as individual EARL reports of test-suite conformance. For example `ruby-earl.ttl` is the report for [Ruby RDF::Normalize](https://github.com/ruby-rdf/rdf-normalize).
+Any files ending in `.ttl` (other than `earl.ttl`) are taken as individual EARL reports of `test-suite` conformance. For example, `ruby-earl.ttl` is the report for [Ruby `RDF::Normalize`](https://github.com/ruby-rdf/rdf-normalize).
 
 As described above, each submission should have DOAP, FOAF, and individual Assertion elements.

--- a/reports/README.md
+++ b/reports/README.md
@@ -4,7 +4,7 @@ test subjects claiming JSON-LD processor conformance.
 
 The consolidated report is saved to `index.html` generated
 using the
-[earl-report Ruby gem](https://rubygems.org/gems/earl-report).
+[`earl-report` Ruby gem](https://rubygems.org/gems/earl-report).
 Run it as follows:
 
 ```sh

--- a/reports/Rakefile
+++ b/reports/Rakefile
@@ -1,0 +1,15 @@
+task default: [ "manifests.nt", "earl.ttl", "earl.html" ]
+
+desc "Create concatenated test manifests"
+file "manifests.nt" do
+  require 'rdf'
+  require 'json/ld'
+  require 'rdf/ntriples'
+  require 'rdf/turtle'
+  graph = RDF::Graph.load(
+    File.expand_path("../../tests/manifest-urdna2015.ttl", __FILE__),
+    base_uri: "https://w3c.github.io/rdf-canon/tests/",
+    unique_bnodes: true)
+  puts "write"
+  RDF::NTriples::Writer.open("manifests.nt", unique_bnodes: true, validate: false) {|w| w << graph}
+end

--- a/reports/earl.jsonld
+++ b/reports/earl.jsonld
@@ -1,0 +1,2027 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://www.w3.org/ns/earl#",
+    "foaf:homepage": {
+      "@type": "@id"
+    },
+    "dc": "http://purl.org/dc/terms/",
+    "doap": "http://usefulinc.com/ns/doap#",
+    "earl": "http://www.w3.org/ns/earl#",
+    "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "assertedBy": {
+      "@type": "@id"
+    },
+    "assertions": {
+      "@id": "mf:report",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "bibRef": {
+      "@id": "dc:bibliographicCitation"
+    },
+    "created": {
+      "@id": "doap:created",
+      "@type": "xsd:date"
+    },
+    "description": {
+      "@id": "rdfs:comment",
+      "@language": "en"
+    },
+    "developer": {
+      "@id": "doap:developer",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "doapDesc": {
+      "@id": "doap:description",
+      "@language": "en"
+    },
+    "entries": {
+      "@id": "mf:entries",
+      "@type": "@id",
+      "@container": "@list",
+      "@context": {
+        "assertions": {
+          "@reverse": "earl:test",
+          "@type": "@id",
+          "@container": "@set"
+        }
+      }
+    },
+    "generatedBy": {
+      "@type": "@id"
+    },
+    "homepage": {
+      "@id": "doap:homepage",
+      "@type": "@id"
+    },
+    "language": {
+      "@id": "doap:programming-language"
+    },
+    "license": {
+      "@id": "doap:license",
+      "@type": "@id"
+    },
+    "mode": {
+      "@type": "@id"
+    },
+    "name": {
+      "@id": "doap:name"
+    },
+    "outcome": {
+      "@type": "@id"
+    },
+    "release": {
+      "@id": "doap:release",
+      "@type": "@id"
+    },
+    "revision": {
+      "@id": "doap:revision"
+    },
+    "shortdesc": {
+      "@id": "doap:shortdesc",
+      "@language": "en"
+    },
+    "subject": {
+      "@type": "@id"
+    },
+    "test": {
+      "@type": "@id"
+    },
+    "testAction": {
+      "@id": "mf:action",
+      "@type": "@id"
+    },
+    "testResult": {
+      "@id": "mf:result",
+      "@type": "@id"
+    },
+    "title": {
+      "@id": "mf:name"
+    },
+    "testSubjects": {
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "xsd": {
+      "@id": "http://www.w3.org/2001/XMLSchema#"
+    }
+  },
+  "@id": "",
+  "@type": [
+    "Software",
+    "doap:Project"
+  ],
+  "name": "RDF Dataset Canonicalization 1.0",
+  "bibRef": "[[rdf-canon]]",
+  "generatedBy": {
+    "@id": "https://rubygems.org/gems/earl-report",
+    "@type": [
+      "Software",
+      "doap:Project"
+    ],
+    "name": "earl-report",
+    "shortdesc": "Earl Report summary generator",
+    "doapDesc": "EarlReport generates HTML+RDFa rollups of multiple EARL reports",
+    "homepage": "https://github.com/gkellogg/earl-report",
+    "language": "Ruby",
+    "license": "http://unlicense.org",
+    "release": {
+      "@id": "https://github.com/gkellogg/earl-report/tree/0.8.0",
+      "@type": "doap:Version",
+      "name": "earl-report-0.8.0",
+      "doap:created": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date",
+        "@value": "2023-01-25"
+      },
+      "revision": "0.8.0"
+    },
+    "developer": [
+      {
+        "@id": "https://greggkellogg.net/foaf#me",
+        "@type": [
+          "foaf:Person",
+          "Assertor"
+        ],
+        "foaf:name": "Gregg Kellogg",
+        "foaf:homepage": "https://greggkellogg.net/"
+      }
+    ]
+  },
+  "assertions": [
+    "ruby-earl.ttl"
+  ],
+  "testSubjects": [
+    {
+      "@id": "https://rubygems.org/gems/rdf-normalize",
+      "@type": [
+        "doap:Project",
+        "TestSubject",
+        "Software"
+      ],
+      "name": "Ruby RDF::Normalize",
+      "developer": [
+        {
+          "@id": "https://greggkellogg.net/foaf#me",
+          "@type": [
+            "foaf:Person",
+            "Assertor"
+          ],
+          "foaf:name": "Gregg Kellogg",
+          "foaf:homepage": "https://greggkellogg.net/"
+        }
+      ],
+      "homepage": "https://github.com/ruby-rdf/rdf-normalize",
+      "doapDesc": "RDF::Normalize performs Dataset Canonicalization for RDF.rb.",
+      "language": "Ruby",
+      "release": {
+        "@id": "_:b0",
+        "revision": "0.5.1"
+      }
+    }
+  ],
+  "entries": [
+    {
+      "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015",
+      "@type": [
+        "mf:Manifest",
+        "Report"
+      ],
+      "rdfs:label": "RDF Dataset Canonicalization (URDNA2015)",
+      "rdfs:comment": "Tests the 2015 version of RDF Dataset Canonicalization.",
+      "entries": [
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test001",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "simple id",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test001-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test001-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b125",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test001",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b126",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test002",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "duplicate property iri values",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test002-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test002-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b3",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test002",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b4",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test003",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "bnode",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test003-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test003-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b5",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test003",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b6",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test004",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "bnode plus embed w/subject",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test004-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test004-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b7",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test004",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b8",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test005",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "bnode embed",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test005-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test005-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b9",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test005",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b10",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test006",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "multiple rdf types",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test006-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test006-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b11",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test006",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b12",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test007",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "coerce CURIE value",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test007-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test007-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b13",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test007",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b14",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test008",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "single subject complex",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test008-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test008-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b15",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test008",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b16",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test009",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "multiple subjects - complex",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test009-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test009-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b17",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test009",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b18",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test010",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "type",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test010-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test010-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b19",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test010",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b20",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test011",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "type-coerced type",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test011-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test011-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b21",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test011",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b22",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test012",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "type-coerced type, remove duplicate reference",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test012-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test012-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b23",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test012",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b24",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test013",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "type-coerced type, cycle",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test013-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test013-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b25",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test013",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b26",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test014",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "check types",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test014-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test014-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b27",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test014",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b28",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test015",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "top level context",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test015-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test015-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b29",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test015",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b30",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test016",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "blank node - dual link - embed",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test016-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test016-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b31",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test016",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b32",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test017",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "blank node - dual link - non-embed",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test017-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test017-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b33",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test017",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b34",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test018",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "blank node - self link",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test018-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test018-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b35",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test018",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b36",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test019",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "blank node - disjoint self links",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test019-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test019-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b37",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test019",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b38",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test020",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "blank node - diamond",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test020-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test020-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b39",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test020",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b40",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test021",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "blank node - circle of 2",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test021-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test021-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b41",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test021",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b42",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test022",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "blank node - double circle of 2",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test022-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test022-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b43",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test022",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b44",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test023",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "blank node - circle of 3",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test023-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test023-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b45",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test023",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b46",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test024",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "blank node - double circle of 3 (1-2-3)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test024-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test024-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b47",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test024",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b48",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test025",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "blank node - double circle of 3 (1-3-2)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test025-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test025-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b49",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test025",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b50",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test026",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "blank node - double circle of 3 (2-1-3)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test026-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test026-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b51",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test026",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b52",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test027",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "blank node - double circle of 3 (2-3-1)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test027-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test027-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b53",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test027",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b54",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test028",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "blank node - double circle of 3 (3-2-1)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test028-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test028-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b55",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test028",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b56",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test029",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "blank node - double circle of 3 (3-1-2)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test029-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test029-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b57",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test029",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b58",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test030",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "blank node - point at circle of 3",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test030-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test030-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b59",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test030",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b60",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test031",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "bnode (1)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test031-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test031-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b61",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test031",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b62",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test032",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "bnode (2)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test032-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test032-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b63",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test032",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b64",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test033",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "disjoint identical subgraphs (1)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test033-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test033-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b65",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test033",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b66",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test034",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "disjoint identical subgraphs (2)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test034-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test034-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b67",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test034",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b68",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test035",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "reordered w/strings (1)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test035-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test035-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b69",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test035",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b70",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test036",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "reordered w/strings (2)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test036-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test036-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b71",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test036",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b72",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test037",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "reordered w/strings (3)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test037-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test037-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b73",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test037",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b74",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test038",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "reordered 4 bnodes, reordered 2 properties (1)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test038-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test038-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b75",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test038",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b76",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test039",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "reordered 4 bnodes, reordered 2 properties (2)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test039-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test039-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b77",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test039",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b78",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test040",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "reordered 6 bnodes (1)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test040-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test040-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b79",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test040",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b80",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test041",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "reordered 6 bnodes (2)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test041-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test041-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b81",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test041",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b82",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test042",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "reordered 6 bnodes (3)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test042-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test042-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b83",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test042",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b84",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test043",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "literal with language",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test043-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test043-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b85",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test043",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b86",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test044",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "evil (1)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test044-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test044-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b87",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test044",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b88",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test045",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "evil (2)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test045-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test045-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b89",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test045",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b90",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test046",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "evil (3)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test046-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test046-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b91",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test046",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b92",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test047",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "deep diff (1)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test047-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test047-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b93",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test047",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b94",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test048",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "deep diff (2)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test048-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test048-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b95",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test048",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b96",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test049",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "remove null",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test049-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test049-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b97",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test049",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b98",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test050",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "nulls",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test050-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test050-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b99",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test050",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b100",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test051",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "merging subjects",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test051-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test051-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b101",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test051",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b102",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test052",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "alias keywords",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test052-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test052-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b103",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test052",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b104",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test053",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "@list",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test053-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test053-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b105",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test053",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b106",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test054",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "t-graph",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test054-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test054-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b107",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test054",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b108",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test055",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "simple reorder (1)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test055-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test055-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b109",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test055",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b110",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test056",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "simple reorder (2)",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test056-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test056-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b111",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test056",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b112",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test057",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "unnamed graph",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test057-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test057-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b113",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test057",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b114",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test058",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "unnamed graph with blank node objects",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test058-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test058-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b115",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test058",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b116",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test059",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "n-quads parsing",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test059-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test059-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b117",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test059",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b118",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test060",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "n-quads escaping",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test060-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test060-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b119",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test060",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b120",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test061",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "same literal value with multiple languages",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test061-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test061-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b121",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test061",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b122",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test062",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "same literal value with multiple datatypes",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test062-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test062-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b123",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test062",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b124",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test063",
+          "@type": [
+            "https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest",
+            "TestCriterion",
+            "TestCase"
+          ],
+          "title": "blank node - diamond (with _:b)",
+          "rdfs:comment": "This duplicates #test020, but uses _:b as a blank node prefix",
+          "http://www.w3.org/ns/rdftest#approval": {
+            "@id": "http://www.w3.org/ns/rdftest#Proposed"
+          },
+          "testAction": "https://w3c.github.io/rdf-canon/tests/urdna2015/test063-in.nq",
+          "testResult": "https://w3c.github.io/rdf-canon/tests/urdna2015/test063-urdna2015.nq",
+          "assertions": [
+            {
+              "@id": "_:b1",
+              "@type": "Assertion",
+              "subject": "https://rubygems.org/gems/rdf-normalize",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test063",
+              "assertedBy": "https://greggkellogg.net/foaf#me",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b2",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/reports/earl.ttl
+++ b/reports/earl.ttl
@@ -1,0 +1,1122 @@
+@prefix dc:   <http://purl.org/dc/terms/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+@prefix mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<> a earl:Software, doap:Project ;
+  doap:name "RDF Dataset Canonicalization 1.0" ;
+  dc:bibliographicCitation "[[rdf-canon]]" ;
+  earl:generatedBy <https://rubygems.org/gems/earl-report> ;
+  mf:report earl:ruby-earl.ttl ;
+  earl:testSubjects <https://rubygems.org/gems/rdf-normalize> ;
+  mf:entries (<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015>) .
+
+# Manifests
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015> a mf:Manifest, earl:Report ;
+  rdfs:label "RDF Dataset Canonicalization (URDNA2015)" ;
+  rdfs:comment "Tests the 2015 version of RDF Dataset Canonicalization." ;
+  mf:entries (<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test001>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test002>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test003>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test004>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test005>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test006>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test007>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test008>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test009>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test010>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test011>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test012>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test013>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test014>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test015>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test016>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test017>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test018>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test019>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test020>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test021>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test022>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test023>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test024>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test025>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test026>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test027>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test028>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test029>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test030>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test031>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test032>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test033>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test034>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test035>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test036>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test037>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test038>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test039>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test040>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test041>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test042>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test043>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test044>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test045>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test046>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test047>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test048>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test049>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test050>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test051>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test052>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test053>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test054>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test055>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test056>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test057>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test058>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test059>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test060>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test061>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test062>
+    <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test063>) .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test001> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "simple id" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test001-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test001-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test001> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test002> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "duplicate property iri values" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test002-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test002-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test002> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test003> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "bnode" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test003-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test003-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test003> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test004> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "bnode plus embed w/subject" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test004-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test004-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test004> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test005> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "bnode embed" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test005-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test005-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test005> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test006> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "multiple rdf types" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test006-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test006-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test006> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test007> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "coerce CURIE value" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test007-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test007-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test007> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test008> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "single subject complex" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test008-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test008-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test008> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test009> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "multiple subjects - complex" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test009-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test009-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test009> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test010> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "type" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test010-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test010-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test010> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test011> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "type-coerced type" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test011-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test011-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test011> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test012> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "type-coerced type, remove duplicate reference" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test012-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test012-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test012> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test013> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "type-coerced type, cycle" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test013-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test013-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test013> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test014> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "check types" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test014-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test014-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test014> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test015> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "top level context" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test015-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test015-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test015> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test016> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "blank node - dual link - embed" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test016-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test016-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test016> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test017> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "blank node - dual link - non-embed" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test017-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test017-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test017> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test018> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "blank node - self link" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test018-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test018-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test018> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test019> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "blank node - disjoint self links" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test019-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test019-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test019> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test020> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "blank node - diamond" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test020-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test020-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test020> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test021> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "blank node - circle of 2" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test021-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test021-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test021> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test022> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "blank node - double circle of 2" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test022-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test022-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test022> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test023> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "blank node - circle of 3" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test023-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test023-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test023> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test024> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "blank node - double circle of 3 (1-2-3)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test024-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test024-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test024> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test025> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "blank node - double circle of 3 (1-3-2)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test025-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test025-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test025> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test026> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "blank node - double circle of 3 (2-1-3)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test026-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test026-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test026> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test027> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "blank node - double circle of 3 (2-3-1)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test027-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test027-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test027> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test028> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "blank node - double circle of 3 (3-2-1)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test028-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test028-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test028> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test029> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "blank node - double circle of 3 (3-1-2)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test029-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test029-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test029> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test030> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "blank node - point at circle of 3" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test030-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test030-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test030> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test031> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "bnode (1)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test031-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test031-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test031> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test032> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "bnode (2)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test032-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test032-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test032> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test033> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "disjoint identical subgraphs (1)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test033-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test033-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test033> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test034> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "disjoint identical subgraphs (2)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test034-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test034-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test034> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test035> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "reordered w/strings (1)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test035-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test035-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test035> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test036> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "reordered w/strings (2)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test036-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test036-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test036> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test037> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "reordered w/strings (3)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test037-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test037-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test037> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test038> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "reordered 4 bnodes, reordered 2 properties (1)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test038-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test038-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test038> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test039> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "reordered 4 bnodes, reordered 2 properties (2)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test039-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test039-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test039> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test040> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "reordered 6 bnodes (1)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test040-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test040-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test040> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test041> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "reordered 6 bnodes (2)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test041-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test041-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test041> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test042> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "reordered 6 bnodes (3)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test042-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test042-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test042> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test043> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "literal with language" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test043-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test043-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test043> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test044> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "evil (1)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test044-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test044-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test044> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test045> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "evil (2)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test045-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test045-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test045> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test046> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "evil (3)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test046-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test046-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test046> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test047> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "deep diff (1)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test047-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test047-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test047> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test048> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "deep diff (2)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test048-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test048-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test048> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test049> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "remove null" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test049-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test049-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test049> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test050> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "nulls" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test050-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test050-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test050> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test051> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "merging subjects" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test051-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test051-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test051> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test052> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "alias keywords" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test052-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test052-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test052> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test053> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "@list" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test053-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test053-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test053> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test054> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "t-graph" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test054-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test054-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test054> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test055> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "simple reorder (1)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test055-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test055-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test055> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test056> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "simple reorder (2)" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test056-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test056-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test056> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test057> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "unnamed graph" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test057-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test057-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test057> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test058> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "unnamed graph with blank node objects" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test058-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test058-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test058> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test059> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "n-quads parsing" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test059-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test059-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test059> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test060> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "n-quads escaping" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test060-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test060-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test060> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test061> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "same literal value with multiple languages" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test061-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test061-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test061> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test062> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "same literal value with multiple datatypes" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test062-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test062-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test062> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test063> a <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest>, earl:TestCriterion, earl:TestCase ;
+  mf:name "blank node - diamond (with _:b)" ;
+  rdfs:comment "This duplicates #test020, but uses _:b as a blank node prefix" ;
+  <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> ;
+  mf:action <https://w3c.github.io/rdf-canon/tests/urdna2015/test063-in.nq> ;
+  mf:result <https://w3c.github.io/rdf-canon/tests/urdna2015/test063-urdna2015.nq> ;
+  earl:assertions [
+    a earl:Assertion ;
+    earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test063> ;
+    earl:subject <https://rubygems.org/gems/rdf-normalize> ;
+    earl:result [
+      a earl:TestResult ;
+      earl:outcome earl:passed
+    ] ;
+    earl:assertedBy <https://greggkellogg.net/foaf#me> ;
+  ] .
+
+<https://rubygems.org/gems/rdf-normalize> a doap:Project, earl:TestSubject, earl:Software ;
+  doap:name "Ruby RDF::Normalize" ;
+  doap:developer <https://greggkellogg.net/foaf#me> ;
+  doap:homepage <https://github.com/ruby-rdf/rdf-normalize> ;
+  doap:description "RDF::Normalize performs Dataset Canonicalization for RDF.rb."@en ;
+  doap:programming-language "Ruby" ;
+  doap:release [doap:revision "0.5.1"] .
+
+<https://greggkellogg.net/foaf#me> a foaf:Person, earl:Assertor ;
+  foaf:name "Gregg Kellogg" ;
+  foaf:homepage <https://greggkellogg.net/> .
+
+
+# Report Generation Software
+<https://rubygems.org/gems/earl-report> a earl:Software, doap:Project;
+   doap:name "earl-report";
+   doap:shortdesc "Earl Report summary generator"@en;
+   doap:description "EarlReport generates HTML+RDFa rollups of multiple EARL reports"@en;
+   doap:homepage <https://github.com/gkellogg/earl-report>;
+   doap:programming-language "Ruby";
+   doap:license <http://unlicense.org>;
+   doap:release <https://github.com/gkellogg/earl-report/tree/0.8.0>;
+   doap:developer <https://greggkellogg.net/foaf#me> .
+
+<https://github.com/gkellogg/earl-report/tree/0.8.0> a doap:Version;
+  doap:name "earl-report-0.8.0";
+  doap:created "2023-01-25"^^xsd:date;
+  doap:revision "0.8.0" .

--- a/reports/index.html
+++ b/reports/index.html
@@ -1,0 +1,911 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta content='text/html;charset=utf-8' http-equiv='Content-Type' />
+<link href='earl.jsonld' rel='alternate' />
+<link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' />
+<link href='ruby-earl.ttl' rel='related' />
+<title>
+RDF Dataset Canonicalization and Hash 1.0 Processor Conformance
+</title>
+<style type='text/css'>
+  /*<![CDATA[*/
+    span[property='dc:description rdfs:comment'] { display: none; }
+    td.PASS { color: green; }
+    td.FAIL { color: red; }
+    table.report {
+      border-width: 1px;
+      border-spacing: 2px;
+      border-style: outset;
+      border-color: gray;
+      border-collapse: separate;
+      background-color: white;
+    }
+    table.report th {
+      border-width: 1px;
+      padding: 1px;
+      border-style: inset;
+      border-color: gray;
+      background-color: white;
+      -moz-border-radius: ;
+    }
+    table.report td {
+      border-width: 1px;
+      padding: 1px;
+      border-style: inset;
+      border-color: gray;
+      background-color: white;
+      -moz-border-radius: ;
+    }
+    tr.summary {font-weight: bold;}
+    td.passed-all {color: green;}
+    td.passed-most {color: darkorange;}
+    td.passed-some {color: red;}
+    em.rfc2119 {
+      text-transform: lowercase;
+      font-variant:   small-caps;
+      font-style:     normal;
+      color:          #900;
+    }
+    a.testlink {
+      color: inherit;
+      text-decoration: none;
+    }
+    a.testlink:hover {
+      text-decoration: underline;
+    }
+    pre > code {
+      color: #C83500;
+    }
+    .non-normative, .non-normative a:visited, .non-normative a:link {
+      color: gray;
+    }
+    #test-manifests .report td:last-child::before {
+      position: absolute;
+      left: 1em;
+      content: "X";
+      color: red;
+      font-weight: bold;
+    }
+    #test-manifests .report tr.summary td:last-child::before,
+    #test-manifests .report .PASS ~ td.PASS:last-child::before,
+    #test-manifests .report .PASS ~ .PASS ~ td:last-child::before {
+      display: none;
+    }
+  /*]]>*/
+</style>
+</head>
+<body prefix='bibo: http://purl.org/ontology/bibo/ earl: http://www.w3.org/ns/earl# doap: http://usefulinc.com/ns/doap# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#' vocab='http://www.w3.org/ns/earl#'>
+<div class='head' role='contentinfo'>
+<p>
+<a href='https://www.w3.org/'>
+<img alt='W3C' height='48' src='https://www.w3.org/Icons/w3c_home' width='72' />
+</a>
+</p>
+<h1 class='title p-name' id='title' property='dc:title'>
+RDF Dataset Canonicalization and Hash 1.0 Processor Conformance
+</h1>
+<h2 class='subtitle'>
+EARL results from the RDF Dataset Canonicalization and Hash 1.0 Test Suite
+</h2>
+<h2 id='w3c-document-28-october-2015'>
+<time class='dt-published' datetime='2023-01-25' property='dc:issued'>
+25 January 2023
+</time>
+</h2>
+<dl>
+<dt>Editor:</dt><dd inlist='inlist' property='bibo:editor'><span typeof='foaf:Person'><meta content='Gregg Kellogg' property='foaf:name' /><a property='foaf:homepage'>Gregg Kellogg</a></span></dd></dl>
+<p>
+This document is also available in these non-normative formats:
+<a href='earl.jsonld' re='alternate'>JSON-LD</a>
+.
+</p>
+<p class='copyright'>
+<a href='https://www.w3.org/Consortium/Legal/ipr-notice#Copyright'>
+Copyright
+</a>
+© 2010-2023
+<a href='https://www.w3.org/'>
+World Wide Web Consortium
+</a>
+W3C<sup>@</sup>
+<a href='http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer'>liability</a>
+,
+<a href='http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks'>trademark</a>
+and
+<a href='http://www.w3.org/Consortium/Legal/copyright-documents' rel='license'>document use</a>
+rules apply.
+</p>
+<hr />
+</div>
+<section id='abstract'>
+<h2>Abstract</h2>
+<p>
+This document report test subject conformance for and related specifications for
+<span property='doap:name'>RDF Dataset Canonicalization and Hash 1.0 Test Suite</span>
+according to the requirements of the Evaluation and Report Language (EARL) 1.0 Schema
+[<a href='https://www.w3.org/TR/EARL10-Schema/'>EARL10-SCHEMA</a>].
+</p>
+<p>
+This report is also available in alternate formats:
+<a href='earl.ttl'>
+Turtle
+</a>
+and
+<a href='earl.jsonld'>
+JSON-LD
+</a>
+</p>
+</section>
+<section id='sodt'>
+<h2 id='h-sotd' resource='#h-sotd'>
+<span property='xhv:role' resource='xhv:heading'>
+Status of This Document
+</span>
+</h2>
+<p>
+This document is merely a <abbr title='World Wide Web Consortium'>W3C</abbr>-internal  document.
+It has no official standing of any kind and does not represent consensus of the
+<abbr title='World Wide Web Consortium'>W3C</abbr>
+Membership.
+</p>
+<p>
+This report describes the state of implementation conformance at the time of publication.
+</p>
+</section>
+<section id='toc'>
+<h2 class='introductory' id='h-toc' resource='#h-toc'>
+<span property='xhv:role' resource='xhv:heading'>
+Table of Contents
+</span>
+</h2>
+<ul class='toc' id='respecContents' role='directory'>
+<li class='tocline'>
+<a class='tocxref' href='#introduction'>
+<span class='secno'>1.</span>
+Introduction
+</a>
+</li>
+<li class='tocline'>
+<a class='tocxref' href='#instructions-for-submitting-implementation-reports'>
+<span class='secno'>2.</span>
+Instructions for submitting implementation reports
+</a>
+</li>
+<li class='tocline'>
+<a class='tocxref' href='#test-manifests'>
+<span class='secno'>3.</span>
+Test Manifests
+</a>
+<ul class='toc'>
+<li class='tocline'>
+<span class='secno'>3.1</span>
+<a class='tocxref' href='#RDF-Dataset-Canonicalization-(URDNA2015)'>
+RDF Dataset Canonicalization (URDNA2015)
+</a>
+</li>
+</ul>
+</li>
+<li class='tocline'>
+<a class='tocxref' href='#test-subjects'>
+<span class='secno'>A.</span>
+Test Subjects
+</a>
+<ul class='toc'>
+<li class='tocline'>
+<span class='secno'>A.1</span>
+<a class='tocxref' href='#subj_Ruby_RDF_Normalize_Ruby'>
+Ruby RDF::Normalize
+ (Ruby)
+</a>
+</li>
+</ul>
+</li>
+<li class='tocline'>
+<a class='tocxref' href='#individual-test-results'>
+<span class='secno'>B.</span>
+Individual Test Results
+</a>
+</li>
+<li class='tocline'>
+<a class='tocxref' href='#report-generation-software'>
+<span class='secno'>C.</span>
+Report Generation Software
+</a>
+</li>
+</ul>
+</section>
+<section id='introduction'>
+<h2>Introduction</h2>
+
+<p>This implementation report covers the implementations of the RDF Dataset Canonicalization and Hash 1.0
+specifications which have submitted test results. It is intended to be
+maintained by the <a href="https://www.w3.org/groups/wg/rch">RDF Dataset Canonicalization and Hash Working Group</a>.
+The implementation report serves two purposes:</p>
+
+<ol>
+<li><p>To demonstrate that there are multiple, independent implementations of
+the specifications. This is a prerequisite for progression of any
+standard to Recommendation.</p></li>
+<li><p>To catalog the known, conforming implementations and which features
+each supports.</p></li>
+</ol>
+
+<p>There may be other <a href="https://github.com/w3c/rdf-canon/wiki/List-of-available-implementations">implementations</a> which are not listed in this
+report, either due to not submitting tests or by not being intended as
+direct implementations of the specification, but instead layering on
+top of such libraries.</p>
+</section>
+<section id='instructions-for-submitting-implementation-reports'>
+<h2>Instructions for submitting implementation reports</h2>
+
+<p>Reports should be submitted in Turtle format to
+  <a href="mailto:public-rch-wg@w3.org">Public RCH WG</a> or via a Pull
+  Request to the <a href="https://github.com/w3c/rdf-canon/pulls">w3c/rdf-canon</a>.</p>
+
+<p>Tests should be run using the test manifests defined in the
+  <a href="#test-manifests">Test Manifests</a> Section.</p>
+
+<p>Include an <code>earl:Assertion</code> for each test, referencing the test
+  resource from the associated manifest and the test subject being
+  reported upon. See the example below:</p>
+
+<pre><code>  [ a earl:Assertion;&#x000A;    earl:assertedBy &lt;--your-developer-identifier--&gt;;&#x000A;    earl:subject &lt;--your-software-identifier--&gt;;&#x000A;    earl:test &lt;--uri-of-test-from-manifest&gt;;&#x000A;    earl:result [&#x000A;      a earl:TestResult;&#x000A;      earl:outcome earl:passed;&#x000A;      dc:date &quot;2023-01-25T10:18:04-08:00&quot;^^xsd:dateTime];&#x000A;    earl:mode earl:automatic ] .&#x000A;</code></pre>
+
+<p>The Test Subject should be defined as a <code>doap:Project</code>, including the name,
+  homepage and developer(s) of the software (see <a href="https://github.com/edumbill/doap/wiki">DOAP</a>). Optionally, including the
+  project description and programming language. An example test subject description is the following:</p>
+
+<pre><code>  &lt;&gt; foaf:primaryTopic &lt;--your-software-identifier--&gt; ;&#x000A;    dc:issued &quot;2016-12-26T10:18:04-08:00&quot;^^xsd:dateTime ;&#x000A;    foaf:maker &lt;--your-developer-identifier--&gt; .&#x000A;&#x000A;  &lt;--your-software-identifier--&gt; a doap:Project, earl:TestSubject, earl:Software ;&#x000A;    doap:name          &quot;My Cool RDF Canonicalizer&quot; ;&#x000A;    doap:release [&#x000A;      doap:name     &quot;--short name wih version number--&quot;;&#x000A;      doap:revision &quot;--Software version number--&quot; ;&#x000A;      doap:created  &quot;2020-02-19&quot;^^xsd:date;&#x000A;    ] ;&#x000A;    doap:developer     &lt;--your-developer-identifier--&gt; ;&#x000A;    doap:homepage      &lt;--your-software-homepace--&gt; ;&#x000A;    doap:description   &quot;--your-project-description--&quot;@en ;&#x000A;    doap:programming-language &quot;--your-implementation-language--&quot; .&#x000A;</code></pre>
+
+<p>The software developer, either an organization or one or more individuals SHOULD be
+  referenced from <code>doap:developer</code> using <a href="http://xmlns.com/foaf/spec">FOAF</a>. For example:</p>
+
+<pre><code>  &lt;--your-developer-identifier--&gt; a foaf:Person, earl:Assertor;&#x000A;    foaf:name &quot;--My Name--&quot;;&#x000A;    foaf:homepage &lt;--my homepage--&gt; .&#x000A;</code></pre>
+</section>
+<section id='test-manifests'>
+<h2>
+<span class='secno'>3.</span>
+Test Manifests
+</h2>
+<section id='RDF-Dataset-Canonicalization-(URDNA2015)'>
+<h2>
+<span class='secno'>3.1</span>
+<span>RDF Dataset Canonicalization (URDNA2015)</span>
+</h2>
+<p>Tests the 2015 version of RDF Dataset Canonicalization.</p>
+
+<table class='report'>
+<tr>
+<th>
+Test
+</th>
+<th>
+<a href='#subj_Ruby_RDF_Normalize_Ruby'>
+Ruby RDF::Normalize
+<br />
+(Ruby)
+</a>
+</th>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test001'>Test test001: simple id</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test002'>Test test002: duplicate property iri values</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test003'>Test test003: bnode</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test004'>Test test004: bnode plus embed w/subject</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test005'>Test test005: bnode embed</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test006'>Test test006: multiple rdf types</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test007'>Test test007: coerce CURIE value</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test008'>Test test008: single subject complex</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test009'>Test test009: multiple subjects - complex</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test010'>Test test010: type</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test011'>Test test011: type-coerced type</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test012'>Test test012: type-coerced type, remove duplicate reference</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test013'>Test test013: type-coerced type, cycle</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test014'>Test test014: check types</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test015'>Test test015: top level context</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test016'>Test test016: blank node - dual link - embed</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test017'>Test test017: blank node - dual link - non-embed</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test018'>Test test018: blank node - self link</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test019'>Test test019: blank node - disjoint self links</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test020'>Test test020: blank node - diamond</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test021'>Test test021: blank node - circle of 2</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test022'>Test test022: blank node - double circle of 2</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test023'>Test test023: blank node - circle of 3</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test024'>Test test024: blank node - double circle of 3 (1-2-3)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test025'>Test test025: blank node - double circle of 3 (1-3-2)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test026'>Test test026: blank node - double circle of 3 (2-1-3)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test027'>Test test027: blank node - double circle of 3 (2-3-1)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test028'>Test test028: blank node - double circle of 3 (3-2-1)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test029'>Test test029: blank node - double circle of 3 (3-1-2)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test030'>Test test030: blank node - point at circle of 3</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test031'>Test test031: bnode (1)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test032'>Test test032: bnode (2)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test033'>Test test033: disjoint identical subgraphs (1)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test034'>Test test034: disjoint identical subgraphs (2)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test035'>Test test035: reordered w/strings (1)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test036'>Test test036: reordered w/strings (2)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test037'>Test test037: reordered w/strings (3)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test038'>Test test038: reordered 4 bnodes, reordered 2 properties (1)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test039'>Test test039: reordered 4 bnodes, reordered 2 properties (2)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test040'>Test test040: reordered 6 bnodes (1)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test041'>Test test041: reordered 6 bnodes (2)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test042'>Test test042: reordered 6 bnodes (3)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test043'>Test test043: literal with language</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test044'>Test test044: evil (1)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test045'>Test test045: evil (2)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test046'>Test test046: evil (3)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test047'>Test test047: deep diff (1)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test048'>Test test048: deep diff (2)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test049'>Test test049: remove null</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test050'>Test test050: nulls</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test051'>Test test051: merging subjects</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test052'>Test test052: alias keywords</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test053'>Test test053: @list</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test054'>Test test054: t-graph</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test055'>Test test055: simple reorder (1)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test056'>Test test056: simple reorder (2)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test057'>Test test057: unnamed graph</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test058'>Test test058: unnamed graph with blank node objects</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test059'>Test test059: n-quads parsing</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test060'>Test test060: n-quads escaping</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test061'>Test test061: same literal value with multiple languages</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test062'>Test test062: same literal value with multiple datatypes</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='normative'>
+<td>
+<a href='https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test063'>Test test063: blank node - diamond (with _:b)</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='summary'>
+<td>
+Percentage passed out of 63 Tests
+</td>
+<td class='passed-all'>
+100.0%
+</td>
+</tr>
+</table>
+</section>
+</section>
+<section class='appendix' id='test-subjects'>
+<h2>
+<span class='secno'>A.</span>
+Test Subjects
+</h2>
+<p>
+This report was tested using the following test subjects:
+</p>
+<dl>
+<dt id='subj_Ruby_RDF_Normalize_Ruby'>
+<span class='secno'>A.1</span>
+<a href='https://rubygems.org/gems/rdf-normalize'>
+<span about='https://rubygems.org/gems/rdf-normalize' property='doap:name'>Ruby RDF::Normalize</span>
+</a>
+</dt>
+<dd>
+<dl>
+<dt>Description</dt>
+<dd lang='en' property='doap:description'>RDF::Normalize performs Dataset Canonicalization for RDF.rb.</dd>
+<dt>Release</dt>
+<dd property='doap:release'><span property='doap:revision'>0.5.1</span></dd>
+<dt>Programming Language</dt>
+<dd property='doap:programming-language'>Ruby</dd>
+<dt>Home Page</dt>
+<dd>
+<a href='https://github.com/ruby-rdf/rdf-normalize' property='doap:homepage'>
+https://github.com/ruby-rdf/rdf-normalize
+</a>
+</dd>
+<dt>Developer</dt>
+<dd rel='doap:developer'>
+<div>
+<a href='https://greggkellogg.net/foaf#me'>
+<span property='foaf:name'>Gregg Kellogg</span>
+</a>
+<a href='https://greggkellogg.net/' property='foaf:homepage'>
+https://greggkellogg.net/
+</a>
+</div>
+</dd>
+<dt>
+Test Suite Compliance
+</dt>
+<dd>
+<table class='report'>
+<tbody>
+<tr>
+<td>
+
+</td>
+<td class='passed-all'>
+63/63 (100.0%)
+</td>
+</tr>
+</tbody>
+</table>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+<section class='appendix' id='individual-test-results' rel='xhv:related earl:assertions'>
+<h2>
+<span class='secno'>B.</span>
+Individual Test Results
+</h2>
+<p>
+Individual test results used to construct this report are available here:
+</p>
+<ul>
+<li>
+<a class='source' href='ruby-earl.ttl'>ruby-earl.ttl</a>
+</li>
+</ul>
+</section>
+<section class='appendix' id='report-generation-software' property='earl:generatedBy' resource='https://rubygems.org/gems/earl-report' typeof='Software doap:Project'>
+<h2>
+<span class='secno'>C.</span>
+Report Generation Software
+</h2>
+<p>
+This report generated by
+<span property='doap:name'><a href='https://rubygems.org/gems/earl-report'>earl-report</a></span>
+<meta content='Earl Report summary generator' property='doap:shortdesc' />
+<meta content='EarlReport generates HTML+RDFa rollups of multiple EARL reports' property='doap:description' />
+version
+<span property='doap:release' resource='https://github.com/gkellogg/earl-report/tree/0.8.0' typeof='doap:Version'>
+<span property='doap:revision'>0.8.0</span>
+<meta content='earl-report-0.8.0' property='doap:name' />
+<meta datatype='xsd:date' property='doap:created' />
+</span>
+is a
+<span property='doap:programming-language'>Ruby</span>
+application freely available under the generous terms of the <a href='http://unlicense.org' property='doap:license'>Unlicense</a>.
+More information is available at
+<a href='https://github.com/gkellogg/earl-report' property='doap:homepage'>https://github.com/gkellogg/earl-report</a>
+.
+</p>
+<p property='doap:developer' resource='http://greggkellogg.net/foaf#me' typeof='foaf:Person'>
+This software is provided by
+<a href='http://greggkellogg.net/' property='foaf:homepage'><span about='http://greggkellogg.net/foaf#me' property='foaf:name'>Gregg Kellogg</span></a>
+in hopes that it might make the lives of conformance testers easier.
+</p>
+</section>
+</body>
+</html>

--- a/reports/manifests.nt
+++ b/reports/manifests.nt
@@ -1,0 +1,446 @@
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#Manifest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015> <http://www.w3.org/2000/01/rdf-schema#label> "RDF Dataset Canonicalization (URDNA2015)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015> <http://www.w3.org/2000/01/rdf-schema#comment> "Tests the 2015 version of RDF Dataset Canonicalization." .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#entries> _:g5940 .
+_:g5940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test001> .
+_:g5940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5920 .
+_:g5920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test002> .
+_:g5920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5900 .
+_:g5900 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test003> .
+_:g5900 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5880 .
+_:g5880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test004> .
+_:g5880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5860 .
+_:g5860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test005> .
+_:g5860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5840 .
+_:g5840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test006> .
+_:g5840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5820 .
+_:g5820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test007> .
+_:g5820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5800 .
+_:g5800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test008> .
+_:g5800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5780 .
+_:g5780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test009> .
+_:g5780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5760 .
+_:g5760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test010> .
+_:g5760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5740 .
+_:g5740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test011> .
+_:g5740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5720 .
+_:g5720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test012> .
+_:g5720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5700 .
+_:g5700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test013> .
+_:g5700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5680 .
+_:g5680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test014> .
+_:g5680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5660 .
+_:g5660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test015> .
+_:g5660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5640 .
+_:g5640 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test016> .
+_:g5640 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5620 .
+_:g5620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test017> .
+_:g5620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5600 .
+_:g5600 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test018> .
+_:g5600 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5580 .
+_:g5580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test019> .
+_:g5580 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5560 .
+_:g5560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test020> .
+_:g5560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5540 .
+_:g5540 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test021> .
+_:g5540 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5520 .
+_:g5520 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test022> .
+_:g5520 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5500 .
+_:g5500 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test023> .
+_:g5500 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5480 .
+_:g5480 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test024> .
+_:g5480 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5460 .
+_:g5460 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test025> .
+_:g5460 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5440 .
+_:g5440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test026> .
+_:g5440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5420 .
+_:g5420 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test027> .
+_:g5420 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5400 .
+_:g5400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test028> .
+_:g5400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5380 .
+_:g5380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test029> .
+_:g5380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5360 .
+_:g5360 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test030> .
+_:g5360 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5340 .
+_:g5340 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test031> .
+_:g5340 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5320 .
+_:g5320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test032> .
+_:g5320 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5300 .
+_:g5300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test033> .
+_:g5300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5280 .
+_:g5280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test034> .
+_:g5280 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5260 .
+_:g5260 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test035> .
+_:g5260 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5240 .
+_:g5240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test036> .
+_:g5240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5220 .
+_:g5220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test037> .
+_:g5220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5200 .
+_:g5200 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test038> .
+_:g5200 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5180 .
+_:g5180 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test039> .
+_:g5180 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5160 .
+_:g5160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test040> .
+_:g5160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5140 .
+_:g5140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test041> .
+_:g5140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5120 .
+_:g5120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test042> .
+_:g5120 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5100 .
+_:g5100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test043> .
+_:g5100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5080 .
+_:g5080 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test044> .
+_:g5080 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5060 .
+_:g5060 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test045> .
+_:g5060 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5040 .
+_:g5040 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test046> .
+_:g5040 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5020 .
+_:g5020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test047> .
+_:g5020 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g5000 .
+_:g5000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test048> .
+_:g5000 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g4980 .
+_:g4980 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test049> .
+_:g4980 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g4960 .
+_:g4960 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test050> .
+_:g4960 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g4940 .
+_:g4940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test051> .
+_:g4940 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g4920 .
+_:g4920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test052> .
+_:g4920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g4900 .
+_:g4900 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test053> .
+_:g4900 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g4880 .
+_:g4880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test054> .
+_:g4880 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g4860 .
+_:g4860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test055> .
+_:g4860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g4840 .
+_:g4840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test056> .
+_:g4840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g4820 .
+_:g4820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test057> .
+_:g4820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g4800 .
+_:g4800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test058> .
+_:g4800 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g4780 .
+_:g4780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test059> .
+_:g4780 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g4760 .
+_:g4760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test060> .
+_:g4760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g4740 .
+_:g4740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test061> .
+_:g4740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g4720 .
+_:g4720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test062> .
+_:g4720 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g4700 .
+_:g4700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test063> .
+_:g4700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test001> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "simple id" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test001> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test001> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test001-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test001> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test001-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test002> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test002> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "duplicate property iri values" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test002> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test002> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test002-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test002> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test002-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test003> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test003> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "bnode" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test003> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test003> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test003-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test003> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test003-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test004> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test004> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "bnode plus embed w/subject" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test004> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test004> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test004-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test004> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test004-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test005> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test005> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "bnode embed" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test005> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test005> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test005-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test005> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test005-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test006> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test006> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "multiple rdf types" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test006> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test006> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test006-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test006> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test006-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test007> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test007> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "coerce CURIE value" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test007> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test007> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test007-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test007> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test007-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test008> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test008> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "single subject complex" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test008> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test008> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test008-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test008> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test008-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test009> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test009> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "multiple subjects - complex" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test009> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test009> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test009-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test009> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test009-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test010> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test010> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "type" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test010> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test010> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test010-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test010> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test010-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test011> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test011> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "type-coerced type" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test011> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test011> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test011-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test011> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test011-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test012> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test012> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "type-coerced type, remove duplicate reference" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test012> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test012> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test012-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test012> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test012-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test013> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test013> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "type-coerced type, cycle" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test013> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test013> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test013-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test013> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test013-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test014> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test014> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "check types" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test014> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test014> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test014-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test014> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test014-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test015> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test015> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "top level context" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test015> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test015> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test015-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test015> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test015-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test016> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test016> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "blank node - dual link - embed" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test016> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test016> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test016-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test016> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test016-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test017> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test017> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "blank node - dual link - non-embed" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test017> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test017> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test017-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test017> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test017-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test018> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test018> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "blank node - self link" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test018> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test018> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test018-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test018> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test018-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test019> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test019> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "blank node - disjoint self links" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test019> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test019> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test019-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test019> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test019-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test020> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test020> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "blank node - diamond" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test020> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test020> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test020-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test020> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test020-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test021> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test021> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "blank node - circle of 2" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test021> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test021> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test021-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test021> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test021-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test022> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test022> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "blank node - double circle of 2" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test022> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test022> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test022-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test022> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test022-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test023> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test023> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "blank node - circle of 3" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test023> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test023> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test023-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test023> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test023-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test024> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test024> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "blank node - double circle of 3 (1-2-3)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test024> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test024> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test024-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test024> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test024-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test025> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test025> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "blank node - double circle of 3 (1-3-2)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test025> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test025> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test025-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test025> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test025-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test026> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test026> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "blank node - double circle of 3 (2-1-3)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test026> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test026> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test026-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test026> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test026-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test027> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test027> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "blank node - double circle of 3 (2-3-1)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test027> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test027> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test027-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test027> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test027-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test028> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test028> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "blank node - double circle of 3 (3-2-1)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test028> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test028> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test028-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test028> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test028-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test029> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test029> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "blank node - double circle of 3 (3-1-2)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test029> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test029> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test029-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test029> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test029-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test030> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test030> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "blank node - point at circle of 3" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test030> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test030> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test030-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test030> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test030-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test031> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test031> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "bnode (1)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test031> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test031> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test031-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test031> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test031-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test032> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test032> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "bnode (2)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test032> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test032> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test032-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test032> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test032-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test033> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test033> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "disjoint identical subgraphs (1)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test033> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test033> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test033-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test033> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test033-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test034> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test034> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "disjoint identical subgraphs (2)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test034> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test034> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test034-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test034> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test034-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test035> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test035> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "reordered w/strings (1)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test035> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test035> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test035-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test035> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test035-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test036> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test036> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "reordered w/strings (2)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test036> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test036> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test036-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test036> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test036-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test037> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test037> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "reordered w/strings (3)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test037> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test037> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test037-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test037> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test037-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test038> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test038> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "reordered 4 bnodes, reordered 2 properties (1)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test038> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test038> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test038-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test038> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test038-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test039> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test039> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "reordered 4 bnodes, reordered 2 properties (2)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test039> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test039> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test039-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test039> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test039-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test040> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test040> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "reordered 6 bnodes (1)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test040> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test040> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test040-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test040> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test040-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test041> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test041> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "reordered 6 bnodes (2)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test041> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test041> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test041-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test041> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test041-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test042> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test042> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "reordered 6 bnodes (3)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test042> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test042> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test042-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test042> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test042-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test043> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test043> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "literal with language" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test043> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test043> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test043-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test043> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test043-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test044> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test044> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "evil (1)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test044> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test044> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test044-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test044> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test044-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test045> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test045> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "evil (2)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test045> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test045> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test045-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test045> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test045-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test046> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test046> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "evil (3)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test046> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test046> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test046-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test046> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test046-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test047> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test047> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "deep diff (1)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test047> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test047> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test047-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test047> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test047-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test048> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test048> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "deep diff (2)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test048> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test048> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test048-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test048> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test048-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test049> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test049> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "remove null" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test049> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test049> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test049-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test049> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test049-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test050> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test050> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "nulls" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test050> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test050> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test050-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test050> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test050-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test051> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test051> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "merging subjects" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test051> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test051> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test051-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test051> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test051-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test052> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test052> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "alias keywords" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test052> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test052> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test052-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test052> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test052-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test053> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test053> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@list" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test053> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test053> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test053-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test053> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test053-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test054> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test054> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "t-graph" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test054> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test054> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test054-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test054> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test054-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test055> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test055> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "simple reorder (1)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test055> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test055> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test055-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test055> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test055-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test056> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test056> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "simple reorder (2)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test056> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test056> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test056-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test056> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test056-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test057> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test057> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "unnamed graph" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test057> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test057> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test057-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test057> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test057-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test058> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test058> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "unnamed graph with blank node objects" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test058> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test058> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test058-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test058> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test058-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test059> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test059> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "n-quads parsing" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test059> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test059> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test059-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test059> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test059-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test060> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test060> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "n-quads escaping" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test060> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test060> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test060-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test060> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test060-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test061> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test061> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "same literal value with multiple languages" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test061> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test061> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test061-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test061> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test061-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test062> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test062> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "same literal value with multiple datatypes" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test062> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test062> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test062-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test062> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test062-urdna2015.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test063> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/rdf-canon/tests/vocab#Urdna2015EvalTest> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test063> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "blank node - diamond (with _:b)" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test063> <http://www.w3.org/2000/01/rdf-schema#comment> "This duplicates #test020, but uses _:b as a blank node prefix" .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test063> <http://www.w3.org/ns/rdftest#approval> <http://www.w3.org/ns/rdftest#Proposed> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test063> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/rdf-canon/tests/urdna2015/test063-in.nq> .
+<https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test063> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/rdf-canon/tests/urdna2015/test063-urdna2015.nq> .

--- a/reports/ruby-earl.ttl
+++ b/reports/ruby-earl.ttl
@@ -1,0 +1,673 @@
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dc:   <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+@prefix ex:   <http://example.org/> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+
+<https://rubygems.org/gems/rdf-normalize> a doap:Project ;
+  doap:name          "Ruby RDF::Normalize" ;
+  doap:homepage      <https://github.com/ruby-rdf/rdf-normalize> ;
+  doap:license       <https://unlicense.org/1.0/> ;
+  doap:shortdesc     "RDF Dataset Normalization for RDF.rb."@en ;
+  doap:description   "RDF::Normalize performs Dataset Canonicalization for RDF.rb."@en ;
+  doap:created       "2015-05-20"^^xsd:date;
+  doap:programming-language "Ruby" ;
+  doap:implements    <https://www.w3.org/TR/rdf-canon/> ;
+  doap:category      <http://dbpedia.org/resource/Resource_Description_Framework>,
+                     <http://dbpedia.org/resource/Ruby_(programming_language)> ;
+  doap:download-page <https://rubygems.org/gems/rdf-normalize> ;
+  doap:mailing-list  <https://lists.w3.org/Archives/Public/public-rdf-ruby/> ;
+  doap:bug-database  <https://github.com/ruby-rdf/rdf-normalize/issues> ;
+  doap:blog          <https://greggkellogg.net/> ;
+  doap:developer     <https://greggkellogg.net/foaf#me> ;
+  doap:maintainer    <https://greggkellogg.net/foaf#me> ;
+  doap:documenter    <https://greggkellogg.net/foaf#me> ;
+  foaf:maker         <https://greggkellogg.net/foaf#me> ;
+  dc:creator         <https://greggkellogg.net/foaf#me> .
+
+<https://rubygems.org/gems/rdf-normalize> doap:release [
+  doap:name "rdf-normalize-0.5.1";
+  doap:revision "0.5.1";
+  doap:created "2022-11-27"^^xsd:date;
+] .
+<> foaf:primaryTopic <https://rubygems.org/gems/rdf-normalize> ;
+  dc:issued "2023-01-25T15:03:17-08:00"^^xsd:dateTime ;
+  foaf:maker <https://greggkellogg.net/foaf#me> .
+
+<https://greggkellogg.net/foaf#me> a foaf:Person, earl:Assertor;
+  foaf:name "Gregg Kellogg";
+  foaf:title "Implementor";
+  foaf:homepage <https://greggkellogg.net/> .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test001>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test002>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test003>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test004>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test005>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test006>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test007>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test008>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test009>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test010>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test011>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test012>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test013>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test014>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test015>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test016>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test017>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test018>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test019>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test020>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test021>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test022>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test023>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test024>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test025>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test026>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test027>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test028>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test029>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test030>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test031>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test032>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test033>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test034>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test035>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test036>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test037>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test038>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test039>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test040>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test041>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test042>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test043>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test044>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test045>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test046>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test047>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test048>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test049>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test050>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test051>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test052>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test053>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test054>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test055>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test056>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test057>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test058>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test059>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test060>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test061>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test062>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .
+
+[ a earl:Assertion;
+  earl:assertedBy <https://greggkellogg.net/foaf#me>;
+  earl:subject <https://rubygems.org/gems/rdf-normalize>;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest-urdna2015#test063>;
+  earl:result [
+    a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2023-01-25T15:03:17-08:00"^^xsd:dateTime];
+  earl:mode earl:automatic ] .

--- a/reports/template.haml
+++ b/reports/template.haml
@@ -1,0 +1,442 @@
+-# This template is used for generating a rollup EARL report. It expects to be
+-# called with a single _tests_ local with the following structure
+- require 'cgi'
+- require 'digest'
+- editors = [{ name: "Gregg Kellogg", urls: "http://greggkellogg.net/"}]
+- foaf = {name: "Gregg Kellogg", url: "https://greggkellogg.net/foaf#me" }
+
+!!! 5
+%html
+  - subjects = tests['testSubjects']
+  %head
+    %meta{"http-equiv" => "Content-Type", :content => "text/html;charset=utf-8"}
+    %link{rel: "alternate", href: "earl.jsonld"}
+    %link{rel: "stylesheet", href: "https://www.w3.org/StyleSheets/TR/base"}
+    - tests['assertions'].each do |file|
+      %link{rel: "related", href: file}
+    %title
+      RDF Dataset Canonicalization and Hash 1.0 Processor Conformance
+    :css
+      span[property='dc:description rdfs:comment'] { display: none; }
+      td.PASS { color: green; }
+      td.FAIL { color: red; }
+      table.report {
+        border-width: 1px;
+        border-spacing: 2px;
+        border-style: outset;
+        border-color: gray;
+        border-collapse: separate;
+        background-color: white;
+      }
+      table.report th {
+        border-width: 1px;
+        padding: 1px;
+        border-style: inset;
+        border-color: gray;
+        background-color: white;
+        -moz-border-radius: ;
+      }
+      table.report td {
+        border-width: 1px;
+        padding: 1px;
+        border-style: inset;
+        border-color: gray;
+        background-color: white;
+        -moz-border-radius: ;
+      }
+      tr.summary {font-weight: bold;}
+      td.passed-all {color: green;}
+      td.passed-most {color: darkorange;}
+      td.passed-some {color: red;}
+      em.rfc2119 {
+        text-transform: lowercase;
+        font-variant:   small-caps;
+        font-style:     normal;
+        color:          #900;
+      }
+      a.testlink {
+        color: inherit;
+        text-decoration: none;
+      }
+      a.testlink:hover {
+        text-decoration: underline;
+      }
+      pre > code {
+        color: #C83500;
+      }
+      .non-normative, .non-normative a:visited, .non-normative a:link {
+        color: gray;
+      }
+      #test-manifests .report td:last-child::before {
+        position: absolute;
+        left: 1em;
+        content: "X";
+        color: red;
+        font-weight: bold;
+      }
+      #test-manifests .report tr.summary td:last-child::before,
+      #test-manifests .report .PASS ~ td.PASS:last-child::before,
+      #test-manifests .report .PASS ~ .PASS ~ td:last-child::before {
+        display: none;
+      }
+
+  %body{prefix: "bibo: http://purl.org/ontology/bibo/ earl: http://www.w3.org/ns/earl# doap: http://usefulinc.com/ns/doap# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#", vocab: "http://www.w3.org/ns/earl#"}
+    - subject_refs = {}
+    - passed_tests = []
+    - subjects.each_with_index do |subject, index|
+      - frag_id = "subj_#{subject['name']}-#{subject['language']}".gsub(/[\W_]+/, '_')
+      - subject_refs[subject['@id']] = frag_id
+    %div.head{role: :contentinfo}
+      %p
+        %a{href: "https://www.w3.org/"}
+          %img{width: 72, height: 48, src: "https://www.w3.org/Icons/w3c_home", alt: "W3C"}
+      %h1.title.p-name#title{property: "dc:title"}
+        RDF Dataset Canonicalization and Hash 1.0 Processor Conformance
+      %h2.subtitle
+        EARL results from the RDF Dataset Canonicalization and Hash 1.0 Test Suite
+      %h2#w3c-document-28-october-2015
+        %time.dt-published{property: "dc:issued", datetime: Time.now.strftime('%Y-%m-%d')}
+          = Time.now.strftime("%d %B %Y")
+      %dl
+        %dt="Editor:"
+        - editors.each do |ed|
+          %dd{property: "bibo:editor", inlist: true}<>
+            %span{typeof: "foaf:Person"}<>
+              %meta{property: "foaf:name", content: ed[:name]}<>
+              %a{property: "foaf:homepage", href: ed[:url]}<>
+                = ed[:name]
+      %p
+        This document is also available in these non-normative formats:
+        %a{re: "alternate", href: "earl.jsonld"}="JSON-LD"
+        = "."
+      %p.copyright
+        %a{href: "https://www.w3.org/Consortium/Legal/ipr-notice#Copyright"}
+          Copyright
+        © 2010-2023
+        %a{href: "https://www.w3.org/"}
+          World Wide Web Consortium
+        W3C<sup>@</sup>
+        %a{href: "http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer"}="liability"
+        = ","
+        %a{href: "http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks"}="trademark"
+        and
+        %a{rel: "license", href: "http://www.w3.org/Consortium/Legal/copyright-documents"}="document use"
+        rules apply.
+      %hr
+    %section#abstract
+      %h2="Abstract"
+      %p
+        This document report test subject conformance for and related specifications for
+        %span{property: "doap:name"}<="RDF Dataset Canonicalization and Hash 1.0 Test Suite"
+        according to the requirements of the Evaluation and Report Language (EARL) 1.0 Schema
+        [
+        %a{href: "https://www.w3.org/TR/EARL10-Schema/"}<>="EARL10-SCHEMA"
+        ].
+      %p
+        This report is also available in alternate formats:
+        %a{href: "earl.ttl"}
+          Turtle
+        and
+        %a{href: "earl.jsonld"}
+          JSON-LD
+    %section#sodt
+      %h2#h-sotd{resource: "#h-sotd"}
+        %span{property: "xhv:role", resource: "xhv:heading"}
+          Status of This Document
+      %p
+        This document is merely a
+        = " "
+        %abbr{title: "World Wide Web Consortium"}<>="W3C"
+        ="-internal  document."
+        It has no official standing of any kind and does not represent consensus of the
+        %abbr{title: "World Wide Web Consortium"}="W3C"
+        Membership.
+      %p
+        This report describes the state of implementation conformance at the time of publication.
+    %section#toc
+      %h2.introductory#h-toc{resource: "#h-toc"}
+        %span{property: "xhv:role", resource: "xhv:heading"}
+          Table of Contents
+      %ul.toc#respecContents{role: "directory"}
+        %li.tocline
+          %a.tocxref{href: "#introduction"}
+            %span.secno="1."
+            Introduction
+        %li.tocline
+          %a.tocxref{href: "#instructions-for-submitting-implementation-reports"}
+            %span.secno="2."
+            Instructions for submitting implementation reports
+        %li.tocline
+          %a.tocxref{href: "#test-manifests"}
+            %span.secno="3."
+            Test Manifests
+          %ul.toc
+            - tests['entries'].sort_by {|m| m['rdfs:label'].to_s.downcase}.each_with_index do |manifest, ndx|
+              %li.tocline
+                %span.secno="3.#{ndx+1}"
+                %a.tocxref{href: "##{manifest['rdfs:label'].gsub(' ', '-')}"}
+                  ~ manifest['rdfs:label']
+        %li.tocline
+          %a.tocxref{href: "#test-subjects"}
+            %span.secno="A."
+            Test Subjects
+          %ul.toc
+            - subjects.each_with_index do |subject, ndx|
+              %li.tocline
+                %span.secno="A.#{ndx+1}"
+                %a.tocxref{href: "#" + subject_refs[subject['@id']]}
+                  = subject['name']
+                  - if subject['language']
+                    = " (#{subject['language']})"
+        %li.tocline
+          %a.tocxref{href: "#individual-test-results"}
+            %span.secno="B."
+            Individual Test Results
+        %li.tocline
+          %a.tocxref{href: "#report-generation-software"}
+            %span.secno="C."
+            Report Generation Software
+    %section#introduction
+      :markdown
+        ## Introduction
+
+        This implementation report covers the implementations of the RDF Dataset Canonicalization and Hash 1.0
+        specifications which have submitted test results. It is intended to be
+        maintained by the [RDF Dataset Canonicalization and Hash Working Group](https://www.w3.org/groups/wg/rch).
+        The implementation report serves two purposes:
+
+        1. To demonstrate that there are multiple, independent implementations of
+          the specifications. This is a prerequisite for progression of any
+          standard to Recommendation.
+
+        2. To catalog the known, conforming implementations and which features
+          each supports.
+
+        There may be other [implementations](https://github.com/w3c/rdf-canon/wiki/List-of-available-implementations) which are not listed in this
+        report, either due to not submitting tests or by not being intended as
+        direct implementations of the specification, but instead layering on
+        top of such libraries.
+    %section#instructions-for-submitting-implementation-reports
+      :markdown
+        ## Instructions for submitting implementation reports
+
+          Reports should be submitted in Turtle format to
+          [Public RCH WG](mailto:public-rch-wg@w3.org) or via a Pull
+          Request to the [w3c/rdf-canon](https://github.com/w3c/rdf-canon/pulls).
+
+          Tests should be run using the test manifests defined in the
+          [Test Manifests](#test-manifests) Section.
+
+          Include an `earl:Assertion` for each test, referencing the test
+          resource from the associated manifest and the test subject being
+          reported upon. See the example below:
+
+              [ a earl:Assertion;
+                earl:assertedBy <--your-developer-identifier-->;
+                earl:subject <--your-software-identifier-->;
+                earl:test <--uri-of-test-from-manifest>;
+                earl:result [
+                  a earl:TestResult;
+                  earl:outcome earl:passed;
+                  dc:date "2023-01-25T10:18:04-08:00"^^xsd:dateTime];
+                earl:mode earl:automatic ] .
+
+          The Test Subject should be defined as a `doap:Project`, including the name,
+          homepage and developer(s) of the software (see [DOAP](https://github.com/edumbill/doap/wiki)). Optionally, including the
+          project description and programming language. An example test subject description is the following:
+
+              <> foaf:primaryTopic <--your-software-identifier--> ;
+                dc:issued "2016-12-26T10:18:04-08:00"^^xsd:dateTime ;
+                foaf:maker <--your-developer-identifier--> .
+
+              <--your-software-identifier--> a doap:Project, earl:TestSubject, earl:Software ;
+                doap:name          "My Cool RDF Canonicalizer" ;
+                doap:release [
+                  doap:name     "--short name wih version number--";
+                  doap:revision "--Software version number--" ;
+                  doap:created  "2020-02-19"^^xsd:date;
+                ] ;
+                doap:developer     <--your-developer-identifier--> ;
+                doap:homepage      <--your-software-homepace--> ;
+                doap:description   "--your-project-description--"@en ;
+                doap:programming-language "--your-implementation-language--" .
+
+          The software developer, either an organization or one or more individuals SHOULD be
+          referenced from `doap:developer` using [FOAF](http://xmlns.com/foaf/spec). For example:
+
+              <--your-developer-identifier--> a foaf:Person, earl:Assertor;
+                foaf:name "--My Name--";
+                foaf:homepage <--my homepage--> .
+    %section#test-manifests
+      %h2
+        %span.secno="3."
+        Test Manifests
+      - tests['entries'].sort_by {|m| m['rdfs:label'].to_s.downcase}.each_with_index do |manifest, ndx2|
+        - test_cases = manifest['entries']
+        %section{id: manifest['rdfs:label'].gsub(' ', '-')}
+          %h2
+            %span.secno="3.#{ndx2+1}"
+            %span<
+              = manifest['rdfs:label'] ||  'Test Manifest'
+          - Array(manifest['rdfs:comment']).each do |desc|
+            - desc = desc['@value'] if desc.is_a?(Hash)
+            :markdown
+              #{desc}
+          %table.report
+            - skip_subject = {}
+            - passed_tests[ndx2] = []
+            %tr
+              %th
+                Test
+              - subjects.each_with_index do |subject, index|
+                -# If subject is untested for every test in this manifest, skip it
+                - skip_subject[subject['@id']] = manifest['entries'].all? {|t| t['assertions'][index]['result']['outcome'] == 'earl:untested'}
+                - unless skip_subject[subject['@id']]
+                  %th
+                    %a{href: '#' + subject_refs[subject['@id']]}
+                      = subject['name']
+                      - if subject['language']
+                        %br
+                        = "(#{subject['language']})"
+            - test_cases.each do |test|
+              - test['title'] ||= test['rdfs:label']
+              - test['title'] = Array(test['title']).first
+              - option = test.fetch('https://w3c.github.io/json-ld-api/tests/vocab#option', {})
+              - normative = option.fetch('https://w3c.github.io/json-ld-api/tests/vocab#normative', {"@value" => "true"})['@value'] == 'true'
+              %tr{class: normative ? 'normative' : 'non-normative'}
+                %td
+                  %a{href: test['@id']}<
+                    = "Test #{test['@id'].split("#").last}: #{CGI.escapeHTML test['title'].to_s}"
+                  - other = []
+                  - if option['https://w3c.github.io/json-ld-api/tests/vocab#specVersion'] == 'json-ld-1.1'
+                    - other << "new in JSON-LD 1.1"
+                  - if option['https://w3c.github.io/json-ld-api/tests/vocab#processorFeature']
+                    - other << "feature: #{option['https://w3c.github.io/json-ld-api/tests/vocab#processorFeature']}"
+                  - if !normative
+                    - other << "non-normative"
+                  - unless other.empty?
+                    = "(#{other.join(', ')})"
+                -# Order assertions by subject name
+                - subjects.each_with_index do |subject, ndx|
+                  - next if skip_subject[subject['@id']]
+                  - assertion = test['assertions'].detect {|a| a['subject'] == subject['@id']}
+                  - pass_fail = assertion['result']['outcome'].split(':').last.upcase.sub(/(PASS|FAIL)ED$/, '\1')
+                  - passed_tests[ndx2][ndx] = (passed_tests[ndx2][ndx] || 0) + (pass_fail == 'PASS' ? 1 : 0)
+                  %td{class: pass_fail}
+                    = pass_fail
+            %tr.summary
+              %td
+                = "Percentage passed out of #{manifest['entries'].length} Tests"
+              - passed_tests[ndx2].compact.each do |r|
+                - pct = (r * 100.0) / manifest['entries'].length
+                %td{class: (pct == 100.0 ? 'passed-all' : (pct >= 95.0 ? 'passed-most' : 'passed-some'))}
+                  = "#{'%.1f' % pct}%"
+    %section.appendix#test-subjects
+      %h2
+        %span.secno="A."
+        Test Subjects
+      %p
+        This report was tested using the following test subjects:
+      %dl
+        - subjects.each_with_index do |subject, index|
+          %dt{id: subject_refs[subject['@id']]}
+            %span.secno="A.#{index+1}"
+            %a{href: subject['@id']}
+              %span{about: subject['@id'], property: "doap:name"}<= subject['name']
+          %dd
+            %dl
+              - if subject['doapDesc']
+                - subject['doapDesc'] = subject['doapDesc']['@value'] if subject['doapDesc'].is_a?(Hash)
+                %dt= "Description"
+                %dd{property: "doap:description", lang: 'en'}<
+                  ~ CGI.escapeHTML subject['doapDesc']
+              - if subject['release']
+                - subject['release'] = subject['release'].first if subject['release'].is_a?(Array)
+                - subject['release']['revision'] = subject['release']['revision']['@value'] if subject['release']['revision'].is_a?(Hash)
+                %dt= "Release"
+                %dd{property: "doap:release"}<
+                  %span{property: "doap:revision"}<
+                    ~ CGI.escapeHTML subject['release']['revision'].to_s
+              - if subject['language']
+                - subject['language'] = subject['language']['@value'] if subject['language'].is_a?(Hash)
+                %dt= "Programming Language"
+                %dd{property: "doap:programming-language"}<
+                  ~ CGI.escapeHTML subject['language'].to_s
+              - if subject['homepage']
+                %dt= "Home Page"
+                %dd
+                  %a{property: "doap:homepage", href: subject['homepage']}
+                    ~ CGI.escapeHTML subject['homepage'].to_s
+              - if subject['developer']
+                %dt= "Developer"
+                - subject['developer'].each do |dev|
+                  %dd{rel: "doap:developer"}
+                    %div
+                      - if dev.has_key?('@id')
+                        %a{href: dev['@id']}
+                          %span{property: "foaf:name"}<
+                            ~ CGI.escapeHTML dev['foaf:name'].to_s
+                      - else
+                        %span{property: "foaf:name"}<
+                      - if dev['foaf:homepage']
+                        %a{property: "foaf:homepage", href: dev['foaf:homepage']}
+                          ~ CGI.escapeHTML dev['foaf:homepage'].is_a?(Hash) ? dev['foaf:homepage']['@id'] : dev['foaf:homepage']
+              %dt
+                Test Suite Compliance
+              %dd
+                %table.report
+                  %tbody
+                    - tests['entries'].sort_by {|m| m['title'].to_s.downcase}.each_with_index do |manifest, ndx|
+                      - passed = passed_tests[ndx][index].to_i
+                      - next if passed == 0
+                      - total = manifest['entries'].length
+                      - pct = (passed * 100.0) / total
+                      %tr
+                        %td
+                          ~ manifest['title']
+                        %td{class: (pct == 100.0 ? 'passed-all' : (pct >= 85.0 ? 'passed-most' : 'passed-some'))}
+                          = "#{passed}/#{total} (#{'%.1f' % pct}%)"
+    - unless tests['assertions'].empty?
+      %section.appendix#individual-test-results{rel: "xhv:related earl:assertions"}
+        %h2
+          %span.secno="B."
+          Individual Test Results
+        %p
+          Individual test results used to construct this report are available here:
+        %ul
+          - tests['assertions'].each do |file|
+            %li
+              %a.source{href: file}<= file
+    %section.appendix#report-generation-software{property: "earl:generatedBy", resource: tests['generatedBy']['@id'], typeof: tests['generatedBy']['@type'].join(' ')}
+      %h2
+        %span.secno="C."
+        Report Generation Software
+      - doap = tests['generatedBy']
+      - rel = doap['release']
+      %p
+        This report generated by
+        %span{property: "doap:name"}<
+          %a{href: tests['generatedBy']['@id']}<
+            = doap['name']
+        %meta{property: "doap:shortdesc", content: doap['shortdesc']}
+        %meta{property: "doap:description", content: doap['doapDesc']}
+        version
+        %span{property: "doap:release", resource: rel['@id'], typeof: 'doap:Version'}
+          %span{property: "doap:revision"}<=rel['revision']
+          %meta{property: "doap:name", content: rel['name']}
+          %meta{property: "doap:created", content: rel['created'], datatype: "xsd:date"}
+        is a
+        %span{property: "doap:programming-language"}<="Ruby"
+        application freely available under the generous terms of the
+        = " "
+        %a{property: "doap:license", href: doap['license']}<>="Unlicense"
+        = "."
+        More information is available at
+        %a{property: "doap:homepage", href: doap['homepage']}<=doap['homepage']
+        = "."
+      %p{property: "doap:developer", resource: "http://greggkellogg.net/foaf#me", typeof: "foaf:Person"}
+        This software is provided by
+        %a{property: "foaf:homepage", href: "http://greggkellogg.net/"}<
+          %span{about: "http://greggkellogg.net/foaf#me", property: "foaf:name"}<
+            Gregg Kellogg
+        in hopes that it might make the lives of conformance testers easier.


### PR DESCRIPTION
… from EARL submissions. (Seeded with the Ruby RDF::Normalize report).

Eventually, this can be linked from the spec.