### PR TITLE
Remove duplicate tests

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -55,49 +55,25 @@ RDF Dataset Canonicalization Test Cases
 <p property='rdfs:comment'>Includes manifests for different application profiles.</p>
 <p>This page describes RDF Dataset Canonicalization tests for the URDNA2015 profile. These tests are also described in <a href="manifest.jsonld">JSON-LD</a> and <a href="manifest.ttl">Turtle</a> formats for convenience. The manifest vocabulary is described in the <a href="vocab.html">RDF Dataset Canonicalization Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 <p>A previous version of this test suite included tests for the URGNA2012 profile, which is non-normative. Those tests continue to be avaliable in the <a href="https://w3c-ccg.github.io/rdf-dataset-canonicalization/tests">Credentials Community Group repository</a>.</p>
-<h2>General instructions for running the RDF Dataset Canonicalization Test suites</h2>
+<h2 id="general-instructions-for-running-the-rdf-dataset-canonicalization-test-suites">General instructions for running the RDF Dataset Canonicalization Test suites</h2>
 <p>FIXME</p>
-<h2>Contributing Tests</h2>
-<p>The test manifests and entries are built automatically from
-<a href="manifest.csv">manifest.csv</a> using <a href="mk_manifest.rb">mk_manifest.rb</a>,
-where each row defines a combination of Validation tests for the same
-<em>action</em> and implicit files.
-Tests may be contributed via pull request to
-<a href="https://github.com/w3c/rdf-canon">https://github.com/w3c/rdf-canon</a>
-with suitable changes to the
-<a href="manifest.csv">manifest.csv</a> and necessary <em>action</em> and <em>result</em> files.</p>
-<h2>Distribution</h2>
-<p>Distributed under both the
-<a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a>
-and the
-<a href="http://www.w3.org/Consortium/Legal/2008/03-bsd-license">W3C 3-clause BSD License</a>.
-To contribute to a W3C Test Suite, see the
-<a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
-<h2>Disclaimer</h2>
-<p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS,
-TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED &quot;AS IS,&quot;
-AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES,
-EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
-WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
-NON-INFRINGEMENT, OR TITLE;
-THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE;
-NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS
-WILL NOT INFRINGE ANY THIRD PARTY PATENTS,
-COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
-COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL
-OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT
-OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+<h2 id="contributing-tests">Contributing Tests</h2>
+<p>The test manifests and entries are built automatically from <a href="manifest.csv">manifest.csv</a> using <a href="mk_manifest.rb">mk_manifest.rb</a>, where each row defines a combination of Validation tests for the same <em>action</em> and implicit files. Tests may be contributed via pull request to <a href="https://github.com/w3c/rdf-canon">https://github.com/w3c/rdf-canon</a> with suitable changes to the <a href="manifest.csv">manifest.csv</a> and necessary <em>action</em> and <em>result</em> files.</p>
+<h2 id="distribution">Distribution</h2>
+<p>Distributed under both the <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-license">W3C Test Suite License</a> and the <a href="http://www.w3.org/Consortium/Legal/2008/03-bsd-license">W3C 3-clause BSD License</a>. To contribute to a W3C Test Suite, see the <a href="http://www.w3.org/2004/10/27-testcases">policies and contribution forms</a>.</p>
+<h2 id="disclaimer">Disclaimer</h2>
+<p>UNDER BOTH MUTUALLY EXCLUSIVE LICENSES, THIS DOCUMENT AND ALL DOCUMENTS, TESTS AND SOFTWARE THAT LINK THIS STATEMENT ARE PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS. COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
 <section class='contents'>
 <h2>Contents</h2>
 <ol>
 <li>
 <a href='#manifest-urdna2015'>RDF Dataset Canonicalization (URDNA2015)</a>
-– 63 entries
+– 51 entries
 </li>
 </ol>
 </section>
 <section id='manifest-urdna2015' inlist property='mf:entry' resource='manifest-urdna2015' typeof='mf:Manifest'>
-<h2>RDF Dataset Canonicalization (URDNA2015) (63 entries)</h2>
+<h2>RDF Dataset Canonicalization (URDNA2015) (51 entries)</h2>
 <p property='rdfs:comment'>Tests the 2015 version of RDF Dataset Canonicalization.</p>
 <p>
 Instructions specific to running URDNA2015 tests.
@@ -253,31 +229,6 @@ manifest-urdna2015#test006:
 </dd>
 </dl>
 </dd>
-<dt id='manifest-urdna2015#test007'>
-<a class='testlink' href='#manifest-urdna2015#test007'>
-manifest-urdna2015#test007:
-</a>
-<span about='manifest-urdna2015#test007' property='mf:name'>coerce CURIE value</span>
-</dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test007' typeof='rdfc:Urdna2015EvalTest'>
-<div property='rdfs:comment'>
-
-</div>
-<dl class='test-detail'>
-<dt>type</dt>
-<dd>rdfc:Urdna2015EvalTest</dd>
-<dt>approval</dt>
-<dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
-<dt>action</dt>
-<dd>
-<a href='urdna2015/test007-in.nq' property='mf:action'>urdna2015/test007-in.nq</a>
-</dd>
-<dt>result</dt>
-<dd>
-<a href='urdna2015/test007-urdna2015.nq' property='mf:result'>urdna2015/test007-urdna2015.nq</a>
-</dd>
-</dl>
-</dd>
 <dt id='manifest-urdna2015#test008'>
 <a class='testlink' href='#manifest-urdna2015#test008'>
 manifest-urdna2015#test008:
@@ -378,31 +329,6 @@ manifest-urdna2015#test011:
 </dd>
 </dl>
 </dd>
-<dt id='manifest-urdna2015#test012'>
-<a class='testlink' href='#manifest-urdna2015#test012'>
-manifest-urdna2015#test012:
-</a>
-<span about='manifest-urdna2015#test012' property='mf:name'>type-coerced type, remove duplicate reference</span>
-</dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test012' typeof='rdfc:Urdna2015EvalTest'>
-<div property='rdfs:comment'>
-
-</div>
-<dl class='test-detail'>
-<dt>type</dt>
-<dd>rdfc:Urdna2015EvalTest</dd>
-<dt>approval</dt>
-<dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
-<dt>action</dt>
-<dd>
-<a href='urdna2015/test012-in.nq' property='mf:action'>urdna2015/test012-in.nq</a>
-</dd>
-<dt>result</dt>
-<dd>
-<a href='urdna2015/test012-urdna2015.nq' property='mf:result'>urdna2015/test012-urdna2015.nq</a>
-</dd>
-</dl>
-</dd>
 <dt id='manifest-urdna2015#test013'>
 <a class='testlink' href='#manifest-urdna2015#test013'>
 manifest-urdna2015#test013:
@@ -450,31 +376,6 @@ manifest-urdna2015#test014:
 <dt>result</dt>
 <dd>
 <a href='urdna2015/test014-urdna2015.nq' property='mf:result'>urdna2015/test014-urdna2015.nq</a>
-</dd>
-</dl>
-</dd>
-<dt id='manifest-urdna2015#test015'>
-<a class='testlink' href='#manifest-urdna2015#test015'>
-manifest-urdna2015#test015:
-</a>
-<span about='manifest-urdna2015#test015' property='mf:name'>top level context</span>
-</dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test015' typeof='rdfc:Urdna2015EvalTest'>
-<div property='rdfs:comment'>
-
-</div>
-<dl class='test-detail'>
-<dt>type</dt>
-<dd>rdfc:Urdna2015EvalTest</dd>
-<dt>approval</dt>
-<dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
-<dt>action</dt>
-<dd>
-<a href='urdna2015/test015-in.nq' property='mf:action'>urdna2015/test015-in.nq</a>
-</dd>
-<dt>result</dt>
-<dd>
-<a href='urdna2015/test015-urdna2015.nq' property='mf:result'>urdna2015/test015-urdna2015.nq</a>
 </dd>
 </dl>
 </dd>
@@ -853,56 +754,6 @@ manifest-urdna2015#test030:
 </dd>
 </dl>
 </dd>
-<dt id='manifest-urdna2015#test031'>
-<a class='testlink' href='#manifest-urdna2015#test031'>
-manifest-urdna2015#test031:
-</a>
-<span about='manifest-urdna2015#test031' property='mf:name'>bnode (1)</span>
-</dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test031' typeof='rdfc:Urdna2015EvalTest'>
-<div property='rdfs:comment'>
-
-</div>
-<dl class='test-detail'>
-<dt>type</dt>
-<dd>rdfc:Urdna2015EvalTest</dd>
-<dt>approval</dt>
-<dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
-<dt>action</dt>
-<dd>
-<a href='urdna2015/test031-in.nq' property='mf:action'>urdna2015/test031-in.nq</a>
-</dd>
-<dt>result</dt>
-<dd>
-<a href='urdna2015/test031-urdna2015.nq' property='mf:result'>urdna2015/test031-urdna2015.nq</a>
-</dd>
-</dl>
-</dd>
-<dt id='manifest-urdna2015#test032'>
-<a class='testlink' href='#manifest-urdna2015#test032'>
-manifest-urdna2015#test032:
-</a>
-<span about='manifest-urdna2015#test032' property='mf:name'>bnode (2)</span>
-</dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test032' typeof='rdfc:Urdna2015EvalTest'>
-<div property='rdfs:comment'>
-
-</div>
-<dl class='test-detail'>
-<dt>type</dt>
-<dd>rdfc:Urdna2015EvalTest</dd>
-<dt>approval</dt>
-<dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
-<dt>action</dt>
-<dd>
-<a href='urdna2015/test032-in.nq' property='mf:action'>urdna2015/test032-in.nq</a>
-</dd>
-<dt>result</dt>
-<dd>
-<a href='urdna2015/test032-urdna2015.nq' property='mf:result'>urdna2015/test032-urdna2015.nq</a>
-</dd>
-</dl>
-</dd>
 <dt id='manifest-urdna2015#test033'>
 <a class='testlink' href='#manifest-urdna2015#test033'>
 manifest-urdna2015#test033:
@@ -1003,31 +854,6 @@ manifest-urdna2015#test036:
 </dd>
 </dl>
 </dd>
-<dt id='manifest-urdna2015#test037'>
-<a class='testlink' href='#manifest-urdna2015#test037'>
-manifest-urdna2015#test037:
-</a>
-<span about='manifest-urdna2015#test037' property='mf:name'>reordered w/strings (3)</span>
-</dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test037' typeof='rdfc:Urdna2015EvalTest'>
-<div property='rdfs:comment'>
-
-</div>
-<dl class='test-detail'>
-<dt>type</dt>
-<dd>rdfc:Urdna2015EvalTest</dd>
-<dt>approval</dt>
-<dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
-<dt>action</dt>
-<dd>
-<a href='urdna2015/test037-in.nq' property='mf:action'>urdna2015/test037-in.nq</a>
-</dd>
-<dt>result</dt>
-<dd>
-<a href='urdna2015/test037-urdna2015.nq' property='mf:result'>urdna2015/test037-urdna2015.nq</a>
-</dd>
-</dl>
-</dd>
 <dt id='manifest-urdna2015#test038'>
 <a class='testlink' href='#manifest-urdna2015#test038'>
 manifest-urdna2015#test038:
@@ -1100,56 +926,6 @@ manifest-urdna2015#test040:
 <dt>result</dt>
 <dd>
 <a href='urdna2015/test040-urdna2015.nq' property='mf:result'>urdna2015/test040-urdna2015.nq</a>
-</dd>
-</dl>
-</dd>
-<dt id='manifest-urdna2015#test041'>
-<a class='testlink' href='#manifest-urdna2015#test041'>
-manifest-urdna2015#test041:
-</a>
-<span about='manifest-urdna2015#test041' property='mf:name'>reordered 6 bnodes (2)</span>
-</dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test041' typeof='rdfc:Urdna2015EvalTest'>
-<div property='rdfs:comment'>
-
-</div>
-<dl class='test-detail'>
-<dt>type</dt>
-<dd>rdfc:Urdna2015EvalTest</dd>
-<dt>approval</dt>
-<dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
-<dt>action</dt>
-<dd>
-<a href='urdna2015/test041-in.nq' property='mf:action'>urdna2015/test041-in.nq</a>
-</dd>
-<dt>result</dt>
-<dd>
-<a href='urdna2015/test041-urdna2015.nq' property='mf:result'>urdna2015/test041-urdna2015.nq</a>
-</dd>
-</dl>
-</dd>
-<dt id='manifest-urdna2015#test042'>
-<a class='testlink' href='#manifest-urdna2015#test042'>
-manifest-urdna2015#test042:
-</a>
-<span about='manifest-urdna2015#test042' property='mf:name'>reordered 6 bnodes (3)</span>
-</dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test042' typeof='rdfc:Urdna2015EvalTest'>
-<div property='rdfs:comment'>
-
-</div>
-<dl class='test-detail'>
-<dt>type</dt>
-<dd>rdfc:Urdna2015EvalTest</dd>
-<dt>approval</dt>
-<dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
-<dt>action</dt>
-<dd>
-<a href='urdna2015/test042-in.nq' property='mf:action'>urdna2015/test042-in.nq</a>
-</dd>
-<dt>result</dt>
-<dd>
-<a href='urdna2015/test042-urdna2015.nq' property='mf:result'>urdna2015/test042-urdna2015.nq</a>
 </dd>
 </dl>
 </dd>
@@ -1300,106 +1076,6 @@ manifest-urdna2015#test048:
 <dt>result</dt>
 <dd>
 <a href='urdna2015/test048-urdna2015.nq' property='mf:result'>urdna2015/test048-urdna2015.nq</a>
-</dd>
-</dl>
-</dd>
-<dt id='manifest-urdna2015#test049'>
-<a class='testlink' href='#manifest-urdna2015#test049'>
-manifest-urdna2015#test049:
-</a>
-<span about='manifest-urdna2015#test049' property='mf:name'>remove null</span>
-</dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test049' typeof='rdfc:Urdna2015EvalTest'>
-<div property='rdfs:comment'>
-
-</div>
-<dl class='test-detail'>
-<dt>type</dt>
-<dd>rdfc:Urdna2015EvalTest</dd>
-<dt>approval</dt>
-<dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
-<dt>action</dt>
-<dd>
-<a href='urdna2015/test049-in.nq' property='mf:action'>urdna2015/test049-in.nq</a>
-</dd>
-<dt>result</dt>
-<dd>
-<a href='urdna2015/test049-urdna2015.nq' property='mf:result'>urdna2015/test049-urdna2015.nq</a>
-</dd>
-</dl>
-</dd>
-<dt id='manifest-urdna2015#test050'>
-<a class='testlink' href='#manifest-urdna2015#test050'>
-manifest-urdna2015#test050:
-</a>
-<span about='manifest-urdna2015#test050' property='mf:name'>nulls</span>
-</dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test050' typeof='rdfc:Urdna2015EvalTest'>
-<div property='rdfs:comment'>
-
-</div>
-<dl class='test-detail'>
-<dt>type</dt>
-<dd>rdfc:Urdna2015EvalTest</dd>
-<dt>approval</dt>
-<dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
-<dt>action</dt>
-<dd>
-<a href='urdna2015/test050-in.nq' property='mf:action'>urdna2015/test050-in.nq</a>
-</dd>
-<dt>result</dt>
-<dd>
-<a href='urdna2015/test050-urdna2015.nq' property='mf:result'>urdna2015/test050-urdna2015.nq</a>
-</dd>
-</dl>
-</dd>
-<dt id='manifest-urdna2015#test051'>
-<a class='testlink' href='#manifest-urdna2015#test051'>
-manifest-urdna2015#test051:
-</a>
-<span about='manifest-urdna2015#test051' property='mf:name'>merging subjects</span>
-</dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test051' typeof='rdfc:Urdna2015EvalTest'>
-<div property='rdfs:comment'>
-
-</div>
-<dl class='test-detail'>
-<dt>type</dt>
-<dd>rdfc:Urdna2015EvalTest</dd>
-<dt>approval</dt>
-<dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
-<dt>action</dt>
-<dd>
-<a href='urdna2015/test051-in.nq' property='mf:action'>urdna2015/test051-in.nq</a>
-</dd>
-<dt>result</dt>
-<dd>
-<a href='urdna2015/test051-urdna2015.nq' property='mf:result'>urdna2015/test051-urdna2015.nq</a>
-</dd>
-</dl>
-</dd>
-<dt id='manifest-urdna2015#test052'>
-<a class='testlink' href='#manifest-urdna2015#test052'>
-manifest-urdna2015#test052:
-</a>
-<span about='manifest-urdna2015#test052' property='mf:name'>alias keywords</span>
-</dt>
-<dd inlist property='mf:entry' resource='manifest-urdna2015#test052' typeof='rdfc:Urdna2015EvalTest'>
-<div property='rdfs:comment'>
-
-</div>
-<dl class='test-detail'>
-<dt>type</dt>
-<dd>rdfc:Urdna2015EvalTest</dd>
-<dt>approval</dt>
-<dd property='mf:approval' resource='rdft:Proposed'>rdft:Proposed</dd>
-<dt>action</dt>
-<dd>
-<a href='urdna2015/test052-in.nq' property='mf:action'>urdna2015/test052-in.nq</a>
-</dd>
-<dt>result</dt>
-<dd>
-<a href='urdna2015/test052-urdna2015.nq' property='mf:result'>urdna2015/test052-urdna2015.nq</a>
 </dd>
 </dl>
 </dd>
@@ -1662,7 +1338,6 @@ manifest-urdna2015#test063:
 <dd inlist property='mf:entry' resource='manifest-urdna2015#test063' typeof='rdfc:Urdna2015EvalTest'>
 <div property='rdfs:comment'>
 <p>This duplicates #test020, but uses _:b as a blank node prefix</p>
-
 </div>
 <dl class='test-detail'>
 <dt>type</dt>

--- a/tests/manifest-urdna2015.jsonld
+++ b/tests/manifest-urdna2015.jsonld
@@ -89,15 +89,6 @@
       "result": "urdna2015/test006-urdna2015.nq"
     },
     {
-      "id": "manifest-urdna2015#test007",
-      "type": "rdfc:Urdna2015EvalTest",
-      "name": "coerce CURIE value",
-      "comment": null,
-      "approval": "rdft:Proposed",
-      "action": "urdna2015/test007-in.nq",
-      "result": "urdna2015/test007-urdna2015.nq"
-    },
-    {
       "id": "manifest-urdna2015#test008",
       "type": "rdfc:Urdna2015EvalTest",
       "name": "single subject complex",
@@ -134,15 +125,6 @@
       "result": "urdna2015/test011-urdna2015.nq"
     },
     {
-      "id": "manifest-urdna2015#test012",
-      "type": "rdfc:Urdna2015EvalTest",
-      "name": "type-coerced type, remove duplicate reference",
-      "comment": null,
-      "approval": "rdft:Proposed",
-      "action": "urdna2015/test012-in.nq",
-      "result": "urdna2015/test012-urdna2015.nq"
-    },
-    {
       "id": "manifest-urdna2015#test013",
       "type": "rdfc:Urdna2015EvalTest",
       "name": "type-coerced type, cycle",
@@ -159,15 +141,6 @@
       "approval": "rdft:Proposed",
       "action": "urdna2015/test014-in.nq",
       "result": "urdna2015/test014-urdna2015.nq"
-    },
-    {
-      "id": "manifest-urdna2015#test015",
-      "type": "rdfc:Urdna2015EvalTest",
-      "name": "top level context",
-      "comment": null,
-      "approval": "rdft:Proposed",
-      "action": "urdna2015/test015-in.nq",
-      "result": "urdna2015/test015-urdna2015.nq"
     },
     {
       "id": "manifest-urdna2015#test016",
@@ -305,24 +278,6 @@
       "result": "urdna2015/test030-urdna2015.nq"
     },
     {
-      "id": "manifest-urdna2015#test031",
-      "type": "rdfc:Urdna2015EvalTest",
-      "name": "bnode (1)",
-      "comment": null,
-      "approval": "rdft:Proposed",
-      "action": "urdna2015/test031-in.nq",
-      "result": "urdna2015/test031-urdna2015.nq"
-    },
-    {
-      "id": "manifest-urdna2015#test032",
-      "type": "rdfc:Urdna2015EvalTest",
-      "name": "bnode (2)",
-      "comment": null,
-      "approval": "rdft:Proposed",
-      "action": "urdna2015/test032-in.nq",
-      "result": "urdna2015/test032-urdna2015.nq"
-    },
-    {
       "id": "manifest-urdna2015#test033",
       "type": "rdfc:Urdna2015EvalTest",
       "name": "disjoint identical subgraphs (1)",
@@ -359,15 +314,6 @@
       "result": "urdna2015/test036-urdna2015.nq"
     },
     {
-      "id": "manifest-urdna2015#test037",
-      "type": "rdfc:Urdna2015EvalTest",
-      "name": "reordered w/strings (3)",
-      "comment": null,
-      "approval": "rdft:Proposed",
-      "action": "urdna2015/test037-in.nq",
-      "result": "urdna2015/test037-urdna2015.nq"
-    },
-    {
       "id": "manifest-urdna2015#test038",
       "type": "rdfc:Urdna2015EvalTest",
       "name": "reordered 4 bnodes, reordered 2 properties (1)",
@@ -393,24 +339,6 @@
       "approval": "rdft:Proposed",
       "action": "urdna2015/test040-in.nq",
       "result": "urdna2015/test040-urdna2015.nq"
-    },
-    {
-      "id": "manifest-urdna2015#test041",
-      "type": "rdfc:Urdna2015EvalTest",
-      "name": "reordered 6 bnodes (2)",
-      "comment": null,
-      "approval": "rdft:Proposed",
-      "action": "urdna2015/test041-in.nq",
-      "result": "urdna2015/test041-urdna2015.nq"
-    },
-    {
-      "id": "manifest-urdna2015#test042",
-      "type": "rdfc:Urdna2015EvalTest",
-      "name": "reordered 6 bnodes (3)",
-      "comment": null,
-      "approval": "rdft:Proposed",
-      "action": "urdna2015/test042-in.nq",
-      "result": "urdna2015/test042-urdna2015.nq"
     },
     {
       "id": "manifest-urdna2015#test043",
@@ -465,42 +393,6 @@
       "approval": "rdft:Proposed",
       "action": "urdna2015/test048-in.nq",
       "result": "urdna2015/test048-urdna2015.nq"
-    },
-    {
-      "id": "manifest-urdna2015#test049",
-      "type": "rdfc:Urdna2015EvalTest",
-      "name": "remove null",
-      "comment": null,
-      "approval": "rdft:Proposed",
-      "action": "urdna2015/test049-in.nq",
-      "result": "urdna2015/test049-urdna2015.nq"
-    },
-    {
-      "id": "manifest-urdna2015#test050",
-      "type": "rdfc:Urdna2015EvalTest",
-      "name": "nulls",
-      "comment": null,
-      "approval": "rdft:Proposed",
-      "action": "urdna2015/test050-in.nq",
-      "result": "urdna2015/test050-urdna2015.nq"
-    },
-    {
-      "id": "manifest-urdna2015#test051",
-      "type": "rdfc:Urdna2015EvalTest",
-      "name": "merging subjects",
-      "comment": null,
-      "approval": "rdft:Proposed",
-      "action": "urdna2015/test051-in.nq",
-      "result": "urdna2015/test051-urdna2015.nq"
-    },
-    {
-      "id": "manifest-urdna2015#test052",
-      "type": "rdfc:Urdna2015EvalTest",
-      "name": "alias keywords",
-      "comment": null,
-      "approval": "rdft:Proposed",
-      "action": "urdna2015/test052-in.nq",
-      "result": "urdna2015/test052-urdna2015.nq"
     },
     {
       "id": "manifest-urdna2015#test053",

--- a/tests/manifest-urdna2015.ttl
+++ b/tests/manifest-urdna2015.ttl
@@ -22,13 +22,12 @@
   rdfs:label "RDF Dataset Canonicalization (URDNA2015)";
   rdfs:comment "Tests the 2015 version of RDF Dataset Canonicalization.";
   mf:entries (
-    :test001 :test002 :test003 :test004 :test005 :test006 :test007 :test008 :test009 :test010
-    :test011 :test012 :test013 :test014 :test015 :test016 :test017 :test018 :test019 :test020
-    :test021 :test022 :test023 :test024 :test025 :test026 :test027 :test028 :test029 :test030
-    :test031 :test032 :test033 :test034 :test035 :test036 :test037 :test038 :test039 :test040
-    :test041 :test042 :test043 :test044 :test045 :test046 :test047 :test048 :test049 :test050
-    :test051 :test052 :test053 :test054 :test055 :test056 :test057 :test058 :test059 :test060
-    :test061 :test062 :test063
+    :test001 :test002 :test003 :test004 :test005 :test006 :test008 :test009 :test010 :test011
+    :test013 :test014 :test016 :test017 :test018 :test019 :test020 :test021 :test022 :test023
+    :test024 :test025 :test026 :test027 :test028 :test029 :test030 :test033 :test034 :test035
+    :test036 :test038 :test039 :test040 :test043 :test044 :test045 :test046 :test047 :test048
+    :test053 :test054 :test055 :test056 :test057 :test058 :test059 :test060 :test061 :test062
+    :test063
   ) .
 
 :test001 a rdfc:Urdna2015EvalTest;
@@ -73,13 +72,6 @@
   mf:result <urdna2015/test006-urdna2015.nq>;
   .
 
-:test007 a rdfc:Urdna2015EvalTest;
-  mf:name "coerce CURIE value";
-  rdft:approval rdft:Proposed;
-  mf:action <urdna2015/test007-in.nq>;
-  mf:result <urdna2015/test007-urdna2015.nq>;
-  .
-
 :test008 a rdfc:Urdna2015EvalTest;
   mf:name "single subject complex";
   rdft:approval rdft:Proposed;
@@ -108,13 +100,6 @@
   mf:result <urdna2015/test011-urdna2015.nq>;
   .
 
-:test012 a rdfc:Urdna2015EvalTest;
-  mf:name "type-coerced type, remove duplicate reference";
-  rdft:approval rdft:Proposed;
-  mf:action <urdna2015/test012-in.nq>;
-  mf:result <urdna2015/test012-urdna2015.nq>;
-  .
-
 :test013 a rdfc:Urdna2015EvalTest;
   mf:name "type-coerced type, cycle";
   rdft:approval rdft:Proposed;
@@ -127,13 +112,6 @@
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test014-in.nq>;
   mf:result <urdna2015/test014-urdna2015.nq>;
-  .
-
-:test015 a rdfc:Urdna2015EvalTest;
-  mf:name "top level context";
-  rdft:approval rdft:Proposed;
-  mf:action <urdna2015/test015-in.nq>;
-  mf:result <urdna2015/test015-urdna2015.nq>;
   .
 
 :test016 a rdfc:Urdna2015EvalTest;
@@ -241,20 +219,6 @@
   mf:result <urdna2015/test030-urdna2015.nq>;
   .
 
-:test031 a rdfc:Urdna2015EvalTest;
-  mf:name "bnode (1)";
-  rdft:approval rdft:Proposed;
-  mf:action <urdna2015/test031-in.nq>;
-  mf:result <urdna2015/test031-urdna2015.nq>;
-  .
-
-:test032 a rdfc:Urdna2015EvalTest;
-  mf:name "bnode (2)";
-  rdft:approval rdft:Proposed;
-  mf:action <urdna2015/test032-in.nq>;
-  mf:result <urdna2015/test032-urdna2015.nq>;
-  .
-
 :test033 a rdfc:Urdna2015EvalTest;
   mf:name "disjoint identical subgraphs (1)";
   rdft:approval rdft:Proposed;
@@ -283,13 +247,6 @@
   mf:result <urdna2015/test036-urdna2015.nq>;
   .
 
-:test037 a rdfc:Urdna2015EvalTest;
-  mf:name "reordered w/strings (3)";
-  rdft:approval rdft:Proposed;
-  mf:action <urdna2015/test037-in.nq>;
-  mf:result <urdna2015/test037-urdna2015.nq>;
-  .
-
 :test038 a rdfc:Urdna2015EvalTest;
   mf:name "reordered 4 bnodes, reordered 2 properties (1)";
   rdft:approval rdft:Proposed;
@@ -309,20 +266,6 @@
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test040-in.nq>;
   mf:result <urdna2015/test040-urdna2015.nq>;
-  .
-
-:test041 a rdfc:Urdna2015EvalTest;
-  mf:name "reordered 6 bnodes (2)";
-  rdft:approval rdft:Proposed;
-  mf:action <urdna2015/test041-in.nq>;
-  mf:result <urdna2015/test041-urdna2015.nq>;
-  .
-
-:test042 a rdfc:Urdna2015EvalTest;
-  mf:name "reordered 6 bnodes (3)";
-  rdft:approval rdft:Proposed;
-  mf:action <urdna2015/test042-in.nq>;
-  mf:result <urdna2015/test042-urdna2015.nq>;
   .
 
 :test043 a rdfc:Urdna2015EvalTest;
@@ -365,34 +308,6 @@
   rdft:approval rdft:Proposed;
   mf:action <urdna2015/test048-in.nq>;
   mf:result <urdna2015/test048-urdna2015.nq>;
-  .
-
-:test049 a rdfc:Urdna2015EvalTest;
-  mf:name "remove null";
-  rdft:approval rdft:Proposed;
-  mf:action <urdna2015/test049-in.nq>;
-  mf:result <urdna2015/test049-urdna2015.nq>;
-  .
-
-:test050 a rdfc:Urdna2015EvalTest;
-  mf:name "nulls";
-  rdft:approval rdft:Proposed;
-  mf:action <urdna2015/test050-in.nq>;
-  mf:result <urdna2015/test050-urdna2015.nq>;
-  .
-
-:test051 a rdfc:Urdna2015EvalTest;
-  mf:name "merging subjects";
-  rdft:approval rdft:Proposed;
-  mf:action <urdna2015/test051-in.nq>;
-  mf:result <urdna2015/test051-urdna2015.nq>;
-  .
-
-:test052 a rdfc:Urdna2015EvalTest;
-  mf:name "alias keywords";
-  rdft:approval rdft:Proposed;
-  mf:action <urdna2015/test052-in.nq>;
-  mf:result <urdna2015/test052-urdna2015.nq>;
   .
 
 :test053 a rdfc:Urdna2015EvalTest;

--- a/tests/manifest.csv
+++ b/tests/manifest.csv
@@ -5,15 +5,12 @@ test003,bnode,,,TRUE
 test004,bnode plus embed w/subject,,,TRUE
 test005,bnode embed,,,TRUE
 test006,multiple rdf types,,,TRUE
-test007,coerce CURIE value,,,TRUE
 test008,single subject complex,,,TRUE
 test009,multiple subjects - complex,,,TRUE
 test010,type,,,TRUE
 test011,type-coerced type,,,TRUE
-test012,"type-coerced type, remove duplicate reference",,,TRUE
 test013,"type-coerced type, cycle",,,TRUE
 test014,check types,,,TRUE
-test015,top level context,,,TRUE
 test016,blank node - dual link - embed,,,TRUE
 test017,blank node - dual link - non-embed,,,TRUE
 test018,blank node - self link,,,TRUE
@@ -29,28 +26,19 @@ test027,blank node - double circle of 3 (2-3-1),,,TRUE
 test028,blank node - double circle of 3 (3-2-1),,,TRUE
 test029,blank node - double circle of 3 (3-1-2),,,TRUE
 test030,blank node - point at circle of 3,,,TRUE
-test031,bnode (1),,,TRUE
-test032,bnode (2),,,TRUE
 test033,disjoint identical subgraphs (1),,,TRUE
 test034,disjoint identical subgraphs (2),,,TRUE
 test035,reordered w/strings (1),,,TRUE
 test036,reordered w/strings (2),,,TRUE
-test037,reordered w/strings (3),,,TRUE
 test038,"reordered 4 bnodes, reordered 2 properties (1)",,,TRUE
 test039,"reordered 4 bnodes, reordered 2 properties (2)",,,TRUE
 test040,reordered 6 bnodes (1),,,TRUE
-test041,reordered 6 bnodes (2),,,TRUE
-test042,reordered 6 bnodes (3),,,TRUE
 test043,literal with language,,,TRUE
 test044,evil (1),,,TRUE
 test045,evil (2),,,TRUE
 test046,evil (3),,,TRUE
 test047,deep diff (1),,,TRUE
 test048,deep diff (2),,,TRUE
-test049,remove null,,,TRUE
-test050,nulls,,,TRUE
-test051,merging subjects,,,TRUE
-test052,alias keywords,,,TRUE
 test053,@list,,,TRUE
 test054,t-graph,,,TRUE
 test055,simple reorder (1),,,TRUE


### PR DESCRIPTION
The first PR to fix #67.
This request intends to remove the following duplicate tests, which were initially meaningful in their [JSON-LD versions](https://dvcs.w3.org/hg/json-ld/raw-file/default/test-suite/#Normalization) but now result in duplicated or meaningless ones in N-Quads format.
I do not currently re-number them because it affects the other PRs for #67. We can re-number them (if necessary) after all the other PRs have been resolved.

- 007 (coerce CURIE value): only meaningful in JSON-LD. We can skip it because its N-Quads form is almost equivalent to test006.
- 012 (type-coerced type, remove duplicate reference): same as 007. We can skip it because its N-Quads form is almost equivalent to test011.
- 015 (top level context) and 049 (remove null): have no predicates and objects, which causes empty N-Quads.
- 031 (bnode (1)) and 032 (bnode (2)): tests two different blank node labeling (_:a and _:b) result in the same canonical N-Quads. We can omit them because this type of test is already covered by tests 020 and 063.
- 037 (reordered w/strings (3)): can be omitted because it is merely a re-labeling of 036.
- 041 (reordered 6 bnodes (2)) and 042 (reordered 6 bnodes (3)): can be omitted because they are merely re-labeling of 040.
- 050 (nulls): tests null in JSON-LD so that it can be omitted in N-Quads.
- 051 (merging subjects): only meaningful in JSON-LD. It is about merging multi-occurred subjects in JSON-LD.
- 052 (alias keywords): only meaningful in JSON-LD. It is all about aliasing `@id` in JSON-LD.
