### PR TITLE
Rename `_:b*` to `_:e*` in the test 57 (seems to be forgotten in #56)

### DIFF
--- a/tests/urdna2015/test057-in.nq
+++ b/tests/urdna2015/test057-in.nq
@@ -1,2 +1,2 @@
-_:b1 <http://xmlns.com/foaf/0.1/homepage> <http://manu.sporny.org/> _:g .
-_:b1 <http://xmlns.com/foaf/0.1/name> "Manu Sporny" _:g .
+_:e0 <http://xmlns.com/foaf/0.1/homepage> <http://manu.sporny.org/> _:e1 .
+_:e0 <http://xmlns.com/foaf/0.1/name> "Manu Sporny" _:e1 .


### PR DESCRIPTION
This is merely additional patching related to #56, where test 057 has remained with its old `_:b*` labels.