### PR TITLE
"considered isomorphic" is misleading

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -552,9 +552,10 @@
         where the graph component `g` is empty if and only if the
         <a data-lt="RDF triple">triple</a> `&lt; s, p, o >` is in the <a>default graph</a>.
         This algorithm considers an RDF dataset to be a set of quads.
-        Two RDF datasets are considered to be isomorphic (i.e., the same modulo blank nodes),
-        if and only if they return the same canonically labeled list of quads
-        via <a>URDNA2015</a>.</p>
+        It is expected that, for two RDF datasets,
+        <a>URDNA2015</a> returns the same canonically labeled list of quads
+        if and only if the two datasets are isomorphic (i.e., the same modulo blank nodes).
+      </p>
 
       <p><a>URDNA2015</a> consists of several sub-algorithms.
         These sub-algorithms are introduced in the following sub-sections.

--- a/spec/index.html
+++ b/spec/index.html
@@ -551,7 +551,6 @@
         is represented as a set of <a>quads</a> of the form `&lt; s, p, o, g >`
         where the graph component `g` is empty if and only if the
         <a data-lt="RDF triple">triple</a> `&lt; s, p, o >` is in the <a>default graph</a>.
-        This algorithm considers an RDF dataset to be a set of quads.
         It is expected that, for two RDF datasets,
         <a>URDNA2015</a> returns the same canonically labeled list of quads
         if and only if the two datasets are isomorphic (i.e., the same modulo blank nodes).


### PR DESCRIPTION
The main purpose of this PR is to rephrase a sentence, in the overview of URDNA2015, which gave the wrong impression of *defining* what it meant to be isomorphic.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/83.html" title="Last updated on Mar 9, 2023, 8:15 PM UTC (226344a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/83/1eec9a0...226344a.html" title="Last updated on Mar 9, 2023, 8:15 PM UTC (226344a)">Diff</a>