### PR TITLE
Add more general privacy considerations 

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -2674,9 +2674,6 @@
 <section id="privacy-considerations" class="informative">
   <h2>Privacy Considerations</h2>
 
-  <section>
-    <h3>Selective Disclosure Schemes</h3>
-
     <p class="issue" data-number="70" title="Dataset structure might reveal information">
 Add text that warns implementers using this specification in selective
 disclosure schemes that graph structure might reveal information about the
@@ -2686,8 +2683,17 @@ is disclosing the information is a part of a subclass of a population,
 which might be enough to disclose information beyond what the discloser intended to
 disclose.
     </p>
-  </section>
 
+    <p>The nature of the canonicalization algorithm inherently correlates its output,
+      i.e., the canonical labels and the sorted order of quads, with the input dataset.
+      This could pose issues, particularly when dealing with datasets containing personal information.
+      For example, even if certain information is removed from the canonicalized dataset
+      for some privacy-respecting reason, there remains the possibility that a third party
+      could infer the omitted data by analyzing the canonicalized dataset.
+      If it is necessary to decouple the canonicalization algorithm's input and output,
+      some suitable post-processing methods for the output of the canonicalization should be performed.
+      See the Data Integrity specification for more details about such post-processing methods.
+    </p>
 </section>
 
 <section id="security-considerations" class="informative">

--- a/spec/index.html
+++ b/spec/index.html
@@ -2692,6 +2692,9 @@ disclose.
       could infer the omitted data by analyzing the canonicalized dataset.
       If it is necessary to decouple the canonicalization algorithm's input and output,
       some suitable post-processing methods for the output of the canonicalization should be performed.
+      This specification has been designed to help make additional processing easier, but
+      other specifications that build on top of this one are responsible for providing any
+      specific details.
       See the Data Integrity specification for more details about such post-processing methods.
     </p>
 </section>


### PR DESCRIPTION
Based on https://github.com/w3c/rdf-canon/pull/99#issuecomment-1550360393 and the discussion on the [16th May 2023 WG call](https://www.w3.org/2023/05/16-rch-minutes.html), I have rewritten the privacy consideration to be more general and lightweight. The reference to Data Integrity spec is not valid at this time, so it might be better to rewrite it. I would appreciate your comments and suggestions...

Supersedes #99.
Fixes #84.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/101.html" title="Last updated on May 20, 2023, 2:23 AM UTC (66a6878)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/101/7bc4143...66a6878.html" title="Last updated on May 20, 2023, 2:23 AM UTC (66a6878)">Diff</a>