### PR TITLE
Remove "IANA Considerations"

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -2707,13 +2707,6 @@ attacker sends a poisoned dataset might be different from system to system.
     </p>
   </section>
 
-
-  <section id="iana">
-    <h2>IANA Considerations</h2>
-
-    <p class="ednote">TODO</p>
-  </section>
-
   <section>
     <h3>Formal Verification Incomplete</h3>
 
@@ -2731,6 +2724,12 @@ validation, ready in the event that an unrecoverable flaw is found in this algor
     </p>
   </section>
 
+</section>
+
+<section id="iana">
+  <h2>IANA Considerations</h2>
+
+  <p class="ednote">TODO</p>
 </section>
 
 <section id="use-cases" class="informative">

--- a/spec/index.html
+++ b/spec/index.html
@@ -2726,12 +2726,6 @@ validation, ready in the event that an unrecoverable flaw is found in this algor
 
 </section>
 
-<section id="iana">
-  <h2>IANA Considerations</h2>
-
-  <p class="ednote">TODO</p>
-</section>
-
 <section id="use-cases" class="informative">
   <h2>Use Cases</h2>
   <p class="ednote">TBD</p>


### PR DESCRIPTION
Based on @iherman's comment (https://github.com/w3c/rdf-canon/pull/101#pullrequestreview-1434216805);
I think "IANA Considerations" should be moved from Security Considerations as another independent section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/102.html" title="Last updated on May 20, 2023, 2:24 AM UTC (cf9bbd4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/102/7bc4143...cf9bbd4.html" title="Last updated on May 20, 2023, 2:24 AM UTC (cf9bbd4)">Diff</a>