### PR TITLE
Add security considerations text.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -2791,10 +2791,10 @@ disclose.
       information connected to blank nodes in order to ensure that each will
       properly receive its own canonical identifier. This process can be
       exploited by attackers to construct datasets which are known to take
-      large amounts of computing time to canonize, but that do not express
+      large amounts of computing time to canonicalize, but that do not express
       useful information or express it using unnecessary complexity.
       Implementers of the algorithm are expected to add mitigations that will,
-      by default, abort canonizing problematic inputs.
+      by default, abort canonicalizing problematic inputs.
     </p>
     <p>Suggested mitigations include, but are not limited to:
       <ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -2787,31 +2787,29 @@ disclose.
   <section>
     <h3>Dataset Poisoning</h3>
 
-    <p class="issue" data-number="70" title="Attackers can construct poison datasets">
-Add text that warns that attackers can construct datasets which are known to
-take large amounts of compute time to canonize. The algorithm has a mechanism to detect
-and prevent this sort of abuse, but implementers need to ensure that they
-think holistically about their system such as what happens if they don't have
-rate limiting on a service exposed to the Internet and they are the subject of
-a DDoS. Default mechanisms that prevent excessive use of compute when an
-attacker sends a poisoned dataset might be different from system to system.
+    <p>The canonicalization algorithm examines every difference in the
+      information connected to blank nodes in order to ensure that each will
+      properly receive its own canonical identifier. This process can be
+      exploited by attackers to construct datasets which are known to take
+      large amounts of compute time to canonize, but that do not express
+      useful information or express it using unnecessary complexity.
+      Implementers of the algorithm are expected to add mitigations that will,
+      by default, abort canonizing problematic inputs.
     </p>
-  </section>
-
-  <section>
-    <h3>Formal Verification Incomplete</h3>
-
-    <p class="issue" data-number="70" title="Formal verification of algorithm is incomplete">
-Add text that warns implementers that, while the algorithm has a mathematical
-proof associated with it that has had peer review, and while a W3C WG
-has reviewed the algorithms and that there are multiple interoperable
-implementations, that a formal proof using a system such as Coq isn't available
-at this time. We are highly confident of the correctness of the algorithm,
-but we will not be able to say with 100% certainty that it is correct until
-we have a formal, machine-based verification of the proof. Any system that
-utilizes this canonicalization mechanism should have a backup canonicalization
-mechanism, such as JCS, or other mitigations, such as schema-based
-validation, ready in the event that an unrecoverable flaw is found in this algorithm.
+    <p>Suggested mitigations include, but are not limited to:
+      <ul>
+        <li>providing a configurable timeout with a default value applicable to
+          an implementation's common use, and / or
+        <li>providing a configurable limit on the number of iterations of steps
+          performed in the algorithm, particularly recursive steps.
+      <ul>
+    </p>
+    <p>Additionally, software that uses implementations of the algorithm can
+      employ best-practice schema validation to reject data that does not meet
+      application requirements, thereby preventing useless poison datasets from
+      being processed. However, such mitigations are application specific and
+      not directly applicable to implementers of the canonicalization algorithm
+      itself.
     </p>
   </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -2799,10 +2799,10 @@ disclose.
     <p>Suggested mitigations include, but are not limited to:
       <ul>
         <li>providing a configurable timeout with a default value applicable to
-          an implementation's common use, and / or
+          an implementation's common use, and / or</li>
         <li>providing a configurable limit on the number of iterations of steps
-          performed in the algorithm, particularly recursive steps.
-      <ul>
+          performed in the algorithm, particularly recursive steps.</li>
+      </ul>
     </p>
     <p>Additionally, software that uses implementations of the algorithm can
       employ best-practice schema validation to reject data that does not meet

--- a/spec/index.html
+++ b/spec/index.html
@@ -2799,9 +2799,9 @@ disclose.
     <p>Suggested mitigations include, but are not limited to:
       <ul>
         <li>providing a configurable timeout with a default value applicable to
-          an implementation's common use, and / or</li>
+          an implementation's common use</li>
         <li>providing a configurable limit on the number of iterations of steps
-          performed in the algorithm, particularly recursive steps.</li>
+          performed in the algorithm, particularly recursive steps</li>
       </ul>
     </p>
     <p>Additionally, software that uses implementations of the algorithm can

--- a/spec/index.html
+++ b/spec/index.html
@@ -2791,7 +2791,7 @@ disclose.
       information connected to blank nodes in order to ensure that each will
       properly receive its own canonical identifier. This process can be
       exploited by attackers to construct datasets which are known to take
-      large amounts of compute time to canonize, but that do not express
+      large amounts of computing time to canonize, but that do not express
       useful information or express it using unnecessary complexity.
       Implementers of the algorithm are expected to add mitigations that will,
       by default, abort canonizing problematic inputs.


### PR DESCRIPTION
Addresses #70.

This PR removes the issue text in the Security Considerations section and adds text on dataset poisoning. The formal verification text is removed as a non-requirement for this section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/106.html" title="Last updated on Jun 7, 2023, 2:28 PM UTC (55c2aa4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/106/6d2e77f...55c2aa4.html" title="Last updated on Jun 7, 2023, 2:28 PM UTC (55c2aa4)">Diff</a>