### PR TITLE
Adds text to indicate that the algorithms are normative.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -298,7 +298,7 @@
     the <a>canonical n-quads form</a> of an <a>input dataset</a>
     consistent with the algorithms defined in this specification.</p>
 
-  <p>The algorithms in this specification should be considered normative,
+  <p>The algorithms in this specification are normative,
     because to consistently reproduce the same canonical identifiers,
     implementations MUST strictly conform to the steps outlined in these algorithms.</p>
 
@@ -382,7 +382,7 @@
       </dd>
       <dt><dfn class="export">canonicalization function</dfn></dt>
       <dd>A <a>canonicalization function</a> maps <a>RDF datasets</a>
-        into <a data-cite="RDF11-CONCEPTS#dfn-dataset-isomorphism">isomorphic datasets</a>.
+        into <a data-cite="RDF11-CONCEPTS#dfn-dataset-isomorphism">isomorphic datasets</a> [[!RDF11-CONCEPTS]].
         Two datasets produce the same canonical result if and only if they are <a data-cite="RDF11-CONCEPTS#dfn-dataset-isomorphism">isomorphic</a>.
         The <a>RDFC-1.0</a> algorithm implements a <a>canonicalization function</a>.
         Some datasets may be constructed to prevent this algorithm from
@@ -390,8 +390,7 @@
         in a reasonable amount of time,
         in which case the algorithm can be considered to be
         a <dfn class="export">partial canonicalization function</dfn>.
-        For two datasets to be isomorphic, they must have equivalent defined
-        results.
+        
       </dd>
     </dl>
   </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -382,8 +382,8 @@
       </dd>
       <dt><dfn class="export">canonicalization function</dfn></dt>
       <dd>A <a>canonicalization function</a> maps <a>RDF datasets</a>
-        into <a data-cite="RDF11-CONCEPTS#dfn-isomorphic">isomorphic datasets</a>.
-        Two datasets produce the same canonical result if and only if they are <a data-cite="RDF11-CONCEPTS#dfn-isomorphic">isomorphic</a>.
+        into <a data-cite="RDF11-CONCEPTS#dfn-dataset-isomorphism">isomorphic datasets</a>.
+        Two datasets produce the same canonical result if and only if they are <a data-cite="RDF11-CONCEPTS#dfn-dataset-isomorphism">isomorphic</a>.
         The <a>RDFC-1.0</a> algorithm implements a <a>canonicalization function</a>.
         Some datasets may be constructed to prevent this algorithm from
         terminating (see <a href="#dataset-poisoning" class="sectionRef"></a>)

--- a/spec/index.html
+++ b/spec/index.html
@@ -299,15 +299,15 @@
     consistent with the algorithms defined in this specification.</p>
 
   <p>The algorithms in this specification should be considered normative,
-    as to consistently reproduce the same canonical identifiers,
+    because to consistently reproduce the same canonical identifiers,
     implementations MUST strictly conform to the steps outlined in these algorithms.</p>
 
-  <p class="note">Implementers can partially check their level of conformance to
+  <p class="note">Implementers can partially check their level of conformance with
     this specification by successfully passing the test cases of the
     <a href="https://w3c.github.io/rdf-canon/tests/">RDF Dataset Canonicalization test suite</a>.
     Note, however, that passing all the tests in the test
     suite does not imply complete conformance to this specification. It only implies
-    that the implementation conforms to aspects tested by the test suite.</p>
+    that the implementation conforms to the aspects tested by the test suite.</p>
 </section>
 
 <section id="terminology" class="normative">
@@ -384,12 +384,12 @@
       <dd>A <a>canonicalization function</a> maps <a>RDF datasets</a>
         into <a data-cite="RDF11-CONCEPTS#dfn-isomorphic">isomorphic datasets</a>.
         Two datasets produce the same canonical result if and only if they are <a data-cite="RDF11-CONCEPTS#dfn-isomorphic">isomorphic</a>.
-        The <a>RDFC-1.0</a> algorithm implements a <a>canonicalization function</a>,
-        although some datasets may be constructed to prevent this algorithm from
-        terminating (see <a href="#dataset-poisoning" class="sectionRef"></a>).
-        In this case the algorithm can be considered to be
-        a <dfn class="export">canonicalization partial function</dfn>.
-        For two datasets to be isomorphic, they both must have equivalent defined
+        The <a>RDFC-1.0</a> algorithm implements a <a>canonicalization function</a>.
+        Some datasets may be constructed to prevent this algorithm from
+        terminating (see <a href="#dataset-poisoning" class="sectionRef"></a>),
+        in which case the algorithm can be considered to be
+        a <dfn class="export">partial canonicalization function</dfn>.
+        For two datasets to be isomorphic, they must have equivalent defined
         results.
       </dd>
     </dl>

--- a/spec/index.html
+++ b/spec/index.html
@@ -386,8 +386,7 @@
         Two datasets produce the same canonical result if and only if they are <a data-cite="RDF11-CONCEPTS#dfn-dataset-isomorphism">isomorphic</a>.
         The <a>RDFC-1.0</a> algorithm implements a <a>canonicalization function</a>.
         Some datasets may be constructed to prevent this algorithm from
-        terminating (see <a href="#dataset-poisoning" class="sectionRef"></a>)
-        in a reasonable amount of time,
+        terminating in a reasonable amount of time (see <a href="#dataset-poisoning" class="sectionRef"></a>),
         in which case the algorithm can be considered to be
         a <dfn class="export">partial canonicalization function</dfn>.
         

--- a/spec/index.html
+++ b/spec/index.html
@@ -293,7 +293,22 @@
   </section>
 </section>
 
-<section id="conformance"></section>
+<section id="conformance">
+  <p>A conforming processor is a system which can generate
+    the <a>canonical n-quads form</a> of an <a>input dataset</a>
+    consistent with the algorithms defined in this specification.</p>
+
+  <p>The algorithms in this specification should be considered normative,
+    as to consistently reproduce the same canonical identifiers,
+    implementations MUST strictly conform to the steps outlined in these algorithms.</p>
+
+  <p class="note">Implementers can partially check their level of conformance to
+    this specification by successfully passing the test cases of the
+    <a href="https://w3c.github.io/rdf-canon/tests/">RDF Dataset Canonicalization test suite</a>.
+    Note, however, that passing all the tests in the test
+    suite does not imply complete conformance to this specification. It only implies
+    that the implementation conforms to aspects tested by the test suite.</p>
+</section>
 
 <section id="terminology" class="normative">
   <h2>Terminology</h2>
@@ -364,6 +379,18 @@
       <dt><dfn data-lt="quad|quads" class="no-export">quad</dfn></dt>
       <dd>A tuple composed of <a>subject</a>, <a>predicate</a>, <a>object</a>, and <a>graph name</a>.
         This is a generalization of an <a>RDF triple</a> along with a <a>graph name</a>.
+      </dd>
+      <dt><dfn class="export">canonicalization function</dfn></dt>
+      <dd>A <a>canonicalization function</a> maps <a>RDF datasets</a>
+        into <a data-cite="RDF11-CONCEPTS#dfn-isomorphic">isomorphic datasets</a>.
+        Two datasets produce the same canonical result if and only if they are <a data-cite="RDF11-CONCEPTS#dfn-isomorphic">isomorphic</a>.
+        The <a>RDFC-1.0</a> algorithm implements a <a>canonicalization function</a>,
+        although some datasets may be constructed to prevent this algorithm from
+        terminating (see <a href="#dataset-poisoning" class="sectionRef"></a>).
+        In this case the algorithm can be considered to be
+        a <dfn class="export">canonicalization partial function</dfn>.
+        For two datasets to be isomorphic, they both must have equivalent defined
+        results.
       </dd>
     </dl>
   </section>
@@ -456,8 +483,6 @@
     "RDF Canonicalization algorithm version 1.0"
     (<abbr title="RDF Canonicalization algorithm version 1.0"><dfn class="export">RDFC-1.0</dfn></abbr>).</p>
 
-  <p class="issue" data-number="112"></p>
-
   <section id="canon-overview" class="informative">
     <h3>Overview</h3>
 
@@ -498,7 +523,7 @@
         <a>blank node identifiers</a>.</dd>
       <dt><dfn>canonical issuer</dfn></dt>
       <dd>An <a>identifier issuer</a>, initialized with the
-        prefix <code>c14n</code>, for issuing canonical
+        prefix <code>c14n</code> (short for canonicalization), for issuing canonical
         <a>blank node identifiers</a>.
         <div class="note">
           Mapping all <a>blank nodes</a> to use this
@@ -2754,7 +2779,7 @@ disclose.
 <section id="security-considerations" class="informative">
   <h2>Security Considerations</h2>
 
-  <section>
+  <section id="dataset-poisoning" class="informative">
     <h3>Dataset Poisoning</h3>
 
     <p>The canonicalization algorithm examines every difference in the

--- a/spec/index.html
+++ b/spec/index.html
@@ -386,7 +386,8 @@
         Two datasets produce the same canonical result if and only if they are <a data-cite="RDF11-CONCEPTS#dfn-isomorphic">isomorphic</a>.
         The <a>RDFC-1.0</a> algorithm implements a <a>canonicalization function</a>.
         Some datasets may be constructed to prevent this algorithm from
-        terminating (see <a href="#dataset-poisoning" class="sectionRef"></a>),
+        terminating (see <a href="#dataset-poisoning" class="sectionRef"></a>)
+        in a reasonable amount of time,
         in which case the algorithm can be considered to be
         a <dfn class="export">partial canonicalization function</dfn>.
         For two datasets to be isomorphic, they must have equivalent defined


### PR DESCRIPTION
Adds some motivation for why algorithms are considered normative. Adds some definitions for "canonicalization function" and "canonicalization partial function" as suggested in #111.

Fixes #112. Fixes #121.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/126.html" title="Last updated on Jun 14, 2023, 10:46 PM UTC (ad15142)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/126/27fc974...ad15142.html" title="Last updated on Jun 14, 2023, 10:46 PM UTC (ad15142)">Diff</a>