### PR TITLE
Minor update on the rdfjs-c14n earl report

### DIFF
--- a/reports/earl.jsonld
+++ b/reports/earl.jsonld
@@ -135,7 +135,7 @@
       "name": "earl-report-0.8.0",
       "doap:created": {
         "@type": "http://www.w3.org/2001/XMLSchema#date",
-        "@value": "2023-06-12"
+        "@value": "2023-06-14"
       },
       "revision": "0.8.0"
     },
@@ -200,11 +200,11 @@
         }
       ],
       "homepage": "https://iherman.github.io/rdfjs-c14n/",
-      "doapDesc": "Implementation in Typescript of the RDF Canonicalization Algorithm RDFC-1.0, relying on the RDF/JS interfaces",
+      "doapDesc": "Implementation in Typescript of the RDF Canonicalization Algorithm RDFC-1.0, on top of the RDF/JS interfaces",
       "language": "TypeScript",
       "release": {
         "@id": "_:b0",
-        "revision": "1.0.4"
+        "revision": "2.0.0"
       }
     },
     {

--- a/reports/earl.ttl
+++ b/reports/earl.ttl
@@ -2035,9 +2035,9 @@
   doap:name "rdfjs-c14n" ;
   doap:developer <https://www.ivan-herman.net/foaf#me> ;
   doap:homepage <https://iherman.github.io/rdfjs-c14n/> ;
-  doap:description "Implementation in Typescript of the RDF Canonicalization Algorithm RDFC-1.0, relying on the RDF/JS interfaces"@en ;
+  doap:description "Implementation in Typescript of the RDF Canonicalization Algorithm RDFC-1.0, on top of the RDF/JS interfaces"@en ;
   doap:programming-language "TypeScript" ;
-  doap:release [doap:revision "1.0.4"] .
+  doap:release [doap:revision "2.0.0"] .
 
 <https://www.ivan-herman.net/foaf#me> a foaf:Person, earl:Assertor ;
   foaf:name "Ivan Herman" ;
@@ -2069,5 +2069,5 @@
 
 <https://github.com/gkellogg/earl-report/tree/0.8.0> a doap:Version;
   doap:name "earl-report-0.8.0";
-  doap:created "2023-06-12"^^xsd:date;
+  doap:created "2023-06-14"^^xsd:date;
   doap:revision "0.8.0" .

--- a/reports/index.html
+++ b/reports/index.html
@@ -92,8 +92,8 @@ RDF Dataset Canonicalization and Hash 1.0 Processor Conformance
 EARL results from the RDF Dataset Canonicalization and Hash 1.0 Test Suite
 </h2>
 <h2 id='w3c-document-28-october-2015'>
-<time class='dt-published' datetime='2023-06-12' property='dc:issued'>
-12 June 2023
+<time class='dt-published' datetime='2023-06-14' property='dc:issued'>
+14 June 2023
 </time>
 </h2>
 <dl>
@@ -1203,9 +1203,9 @@ Test Suite Compliance
 <dd>
 <dl>
 <dt>Description</dt>
-<dd lang='en' property='doap:description'>Implementation in Typescript of the RDF Canonicalization Algorithm RDFC-1.0, relying on the RDF/JS interfaces</dd>
+<dd lang='en' property='doap:description'>Implementation in Typescript of the RDF Canonicalization Algorithm RDFC-1.0, on top of the RDF/JS interfaces</dd>
 <dt>Release</dt>
-<dd property='doap:release'><span property='doap:revision'>1.0.4</span></dd>
+<dd property='doap:release'><span property='doap:revision'>2.0.0</span></dd>
 <dt>Programming Language</dt>
 <dd property='doap:programming-language'>TypeScript</dd>
 <dt>Home Page</dt>

--- a/reports/rdfjs-c14n-report.ttl
+++ b/reports/rdfjs-c14n-report.ttl
@@ -7,7 +7,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 
 <> foaf:primaryTopic <https://iherman.github.io/rdfjs-c14n/> ;
-  dc:issued  "2023-02-11T08:45:28.357Z"^^xsd:dateTime ;
+  dc:issued  "2023-06-14T11:46:45.444Z"^^xsd:dateTime ;
   foaf:maker <https://www.ivan-herman.net/foaf#me> .
 
 <https://iherman.github.io/rdfjs-c14n/> a doap:Project ;
@@ -15,7 +15,7 @@
   doap:homepage             <https://iherman.github.io/rdfjs-c14n/> ;
   doap:license              <https://www.w3.org/Consortium/Legal/copyright-software> ;
   doap:shortdesc            "RDF Canonicalization in TypeScript."@en ;
-  doap:description          "Implementation in Typescript of the RDF Canonicalization Algorithm RDFC-1.0, relying on the RDF/JS interfaces"@en ;
+  doap:description          "Implementation in Typescript of the RDF Canonicalization Algorithm RDFC-1.0, on top of the RDF/JS interfaces"@en ;
   doap:created              "2023-01-05"^^xsd:date ;
   doap:programming-language "TypeScript" ;
   doap:implements           <https://www.w3.org/TR/rdf-canon/> ;
@@ -31,8 +31,8 @@
   doap:release [
     a doap:Version ;
     doap:name     "rdfjs-c14n";
-    doap:revision "1.0.4";
-    doap:created  "2013-02-11"^^xsd:date ;
+    doap:revision "2.0.0";
+    doap:created  "2013-06-14"^^xsd:date ;
   ] ;
   doap:repository [
     a doap:GitRepository ;
@@ -53,8 +53,8 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
-    ];;
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+    ];
     earl:mode earl:automatic
 ] .
 
@@ -66,7 +66,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -79,7 +79,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -92,7 +92,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -105,7 +105,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -118,7 +118,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -131,7 +131,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -144,7 +144,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -157,7 +157,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -170,7 +170,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -183,7 +183,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -196,7 +196,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -209,7 +209,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -222,7 +222,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -235,7 +235,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -248,7 +248,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -261,7 +261,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -274,7 +274,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -287,7 +287,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -300,7 +300,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -313,7 +313,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -326,7 +326,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -339,7 +339,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -352,7 +352,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -365,7 +365,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -378,7 +378,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -391,7 +391,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -404,7 +404,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -417,7 +417,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -430,7 +430,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -443,7 +443,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -456,7 +456,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -469,7 +469,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -482,7 +482,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -495,7 +495,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -508,7 +508,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -521,7 +521,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -534,7 +534,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -547,7 +547,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -560,7 +560,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -573,7 +573,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -586,7 +586,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -599,7 +599,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -612,7 +612,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -625,7 +625,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -638,7 +638,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -651,7 +651,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -664,7 +664,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -677,7 +677,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -690,7 +690,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -703,7 +703,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -716,7 +716,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -729,7 +729,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -742,7 +742,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -755,7 +755,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -768,7 +768,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -781,7 +781,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-02-11T08:45:28.357Z"^^xsd:dateTime
+        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .


### PR DESCRIPTION
I have updated my implementation to the latest draft, which resulted in some minor change in the Earl report metadata. The test results are unchanged.