### PR TITLE
Clarify that gossip paths are encoded and operated on as strings.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -366,8 +366,9 @@
       <dt><dfn>gossip path</dfn></dt>
       <dd>A particular enumeration of every incident <a>mention</a> emanating
         from a blank node, recursively including transitively related
-        <a>mentions</a> until any named node or canonically labeled blank node
-        is reached. Gossip paths are encoded and operated on in the
+        <a>mentions</a> until any named node or blank node already labeled with
+        using the <a>identifier issuer</a> associated with the gossip path is
+        reached. Gossip paths are encoded and operated on in the
         <a>RDFC-1.0</a> algorithm as strings (see
         <a href="#hash-nd-quads" class="sectionRef"></a> for more information
         on the construction of gossip paths).

--- a/spec/index.html
+++ b/spec/index.html
@@ -368,9 +368,9 @@
         from a blank node. This recursively includes transitively related
         <a>mentions</a> until any named node or blank node already labeled by
         a particular <a>identifier issuer</a> is reached. Gossip paths are
-        encoded and operated on in the <a>RDFC-1.0</a> algorithm as strings (see
+        encoded and operated on in the <a>RDFC-1.0</a> algorithm as strings. (See
         <a href="#hash-nd-quads" class="sectionRef"></a> for more information
-        on the construction of gossip paths).
+        on the construction of gossip paths.)
       </dd>
       <dt><dfn data-lt="canonical n-quads" class="no-export">canonical n-quads form</dfn></dt>
       <dd>
@@ -1865,7 +1865,7 @@
         this by creating deterministic paths that emanate out from the blank
         node through any other adjacent blank nodes.</p>
 
-      <p>Ultimately, the algorithm selects a shortest <a>gossip path</a>
+      <p>Ultimately, the algorithm selects the shortest <a>gossip path</a>
         (based on its encoding as a string), distributing canonical
         identifiers to the unlabeled blank nodes in the order in which they
         appear in this path.

--- a/spec/index.html
+++ b/spec/index.html
@@ -365,11 +365,10 @@
         denoted <var>Q<sub>n</sub></var>.</dd>
       <dt><dfn>gossip path</dfn></dt>
       <dd>A particular enumeration of every incident <a>mention</a> emanating
-        from a blank node, recursively including transitively related
-        <a>mentions</a> until any named node or blank node already labeled with
-        using the <a>identifier issuer</a> associated with the gossip path is
-        reached. Gossip paths are encoded and operated on in the
-        <a>RDFC-1.0</a> algorithm as strings (see
+        from a blank node. This recursively includes transitively related
+        <a>mentions</a> until any named node or blank node already labeled by
+        a particular <a>identifier issuer</a> is reached. Gossip paths are
+        encoded and operated on in the <a>RDFC-1.0</a> algorithm as strings (see
         <a href="#hash-nd-quads" class="sectionRef"></a> for more information
         on the construction of gossip paths).
       </dd>

--- a/spec/index.html
+++ b/spec/index.html
@@ -369,11 +369,13 @@
         of nodes and quads such that the first quad includes
         the starting node as an component, and the last quad includes
         the ending node as an component with each quad in the path
-        containing both the preceding and following nodes.</dd>
+        containing both the preceding and following nodes. Gossip paths are
+        encoded and operated on in the <a>RDFC-1.0</a> algorithm as
+        strings.</dd>
       <dt><dfn data-lt="canonical n-quads" class="no-export">canonical n-quads form</dfn></dt>
       <dd>
         The canonicalized representation of a quad is defined in <a href="#canonical-quads" class="sectionRef"></a>.
-        A quad in <a>canonical n-quads form</a> represents a <a>graph name</a>, if present, in the same manner as 
+        A quad in <a>canonical n-quads form</a> represents a <a>graph name</a>, if present, in the same manner as
         a <a>subject</a>, and each quad is terminated with a single new line character (`U+000A`).
       </dd>
       <dt><dfn data-lt="quad|quads" class="no-export">quad</dfn></dt>
@@ -1863,9 +1865,10 @@
         this by creating deterministic paths that emanate out from the blank
         node through any other adjacent blank nodes.</p>
 
-      <p>Ultimately, the algorithm selects a shortest <a>gossip path</a>,
-        distributing canonical identifiers to the unlabeled blank nodes
-        in the order in which they appear in this path.
+      <p>Ultimately, the algorithm selects a shortest <a>gossip path</a>
+        (based on its encoding as a string), distributing canonical
+        identifiers to the unlabeled blank nodes in the order in which they
+        appear in this path.
         The hash of this encoded shortest path,
         called the N-degree hash of <var>n</var>,
         distinguishes <var>n</var> from other blank nodes in the dataset.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -364,14 +364,14 @@
         that <a>mention</a> a node <var>n</var> is called the <a>mention set</a> of <var>n</var>,
         denoted <var>Q<sub>n</sub></var>.</dd>
       <dt><dfn>gossip path</dfn></dt>
-      <dd>The gossip path between two <a>blank nodes</a> contained within
-        <a>quads</a> in a <a>dataset</a>, where the path is a sequence
-        of nodes and quads such that the first quad includes
-        the starting node as an component, and the last quad includes
-        the ending node as an component with each quad in the path
-        containing both the preceding and following nodes. Gossip paths are
-        encoded and operated on in the <a>RDFC-1.0</a> algorithm as
-        strings.</dd>
+      <dd>A particular enumeration of every incident <a>mention</a> emanating
+        from a blank node, recursively including transitively related
+        <a>mentions</a> until any named node or canonically labeled blank node
+        is reached. Gossip paths are encoded and operated on in the
+        <a>RDFC-1.0</a> algorithm as strings (see
+        <a href="#hash-nd-quads" class="sectionRef"></a> for more information
+        on the construction of gossip paths).
+      </dd>
       <dt><dfn data-lt="canonical n-quads" class="no-export">canonical n-quads form</dfn></dt>
       <dd>
         The canonicalized representation of a quad is defined in <a href="#canonical-quads" class="sectionRef"></a>.


### PR DESCRIPTION
This addresses #113. It also includes a trailing whitespace editorial fix.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/134.html" title="Last updated on Jun 30, 2023, 12:00 AM UTC (0d43f53)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/134/e2332e1...0d43f53.html" title="Last updated on Jun 30, 2023, 12:00 AM UTC (0d43f53)">Diff</a>