### PR TITLE
Add note about hash parameterization.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -353,7 +353,12 @@
       <dt><dfn>hash</dfn></dt>
       <dd>The lowercase, hexadecimal representation of a message digest.</dd>
       <dt><dfn>hash algorithm</dfn></dt>
-      <dd>The hash algorithm used by <a>RDFC-1.0</a>, namely, SHA-256.</dd>
+      <dd>The hash algorithm used by <a>RDFC-1.0</a>, namely, SHA-256.
+        <div class="note">Implementations can be written to parameterize the
+        hash algorithm without any other changes. However, using a different
+        hash algorithm is expected to generate different output from
+        <a>RDFC-1.0</a>.</div>
+      </dd>
       <dt><dfn>mention</dfn></dt>
       <dd>
         A node is mentioned in a <a>quad</a>


### PR DESCRIPTION
This PR adds an informative note to be clear that the core algorithm treats the hash algorithm as separable but calls out a very specific algorithm for RDFC-1.0 for interoperability purposes. In other words, implementations can be written such that they parameterize the hash algorithm, but using another algorithm would not be interoperable with RDFC-1.0. This just makes it more clear that there's flexibility for future specs that build on this one without affecting the rest of the algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/135.html" title="Last updated on Jun 28, 2023, 10:52 PM UTC (285f862)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/135/e2332e1...285f862.html" title="Last updated on Jun 28, 2023, 10:52 PM UTC (285f862)">Diff</a>