### PR TITLE
Updated rdfjs-c14n-report

### DIFF
--- a/reports/earl.jsonld
+++ b/reports/earl.jsonld
@@ -135,7 +135,7 @@
       "name": "earl-report-0.8.0",
       "doap:created": {
         "@type": "http://www.w3.org/2001/XMLSchema#date",
-        "@value": "2023-07-04"
+        "@value": "2023-07-05"
       },
       "revision": "0.8.0"
     },
@@ -204,7 +204,7 @@
       "language": "TypeScript",
       "release": {
         "@id": "_:b0",
-        "revision": "2.0.0"
+        "revision": "2.0.2"
       }
     },
     {
@@ -230,7 +230,7 @@
       "doapDesc": "RDF::Normalize performs Dataset Canonicalization for RDF.rb.",
       "language": "Ruby",
       "release": {
-        "@id": "_:b115",
+        "@id": "_:b1",
         "revision": "0.6.0"
       }
     }
@@ -261,40 +261,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test001-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b280",
+              "@id": "_:b166",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test001c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b281",
+                "@id": "_:b167",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b1",
+              "@id": "_:b280",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test001c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b2",
+                "@id": "_:b281",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b116",
+              "@id": "_:b2",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test001c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b117",
+                "@id": "_:b3",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -317,40 +316,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test002-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b282",
+              "@id": "_:b168",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test002c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b283",
+                "@id": "_:b169",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b3",
+              "@id": "_:b282",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test002c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b4",
+                "@id": "_:b283",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b118",
+              "@id": "_:b4",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test002c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b119",
+                "@id": "_:b5",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -373,40 +371,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test003-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b284",
+              "@id": "_:b170",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b285",
+                "@id": "_:b171",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b5",
+              "@id": "_:b284",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b6",
+                "@id": "_:b285",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b120",
+              "@id": "_:b6",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b121",
+                "@id": "_:b7",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -429,38 +426,38 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test003-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b396",
+              "@id": "_:b288",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003m",
               "result": {
-                "@id": "_:b397",
+                "@id": "_:b289",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b394",
+              "@id": "_:b286",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003m",
               "result": {
-                "@id": "_:b395",
+                "@id": "_:b287",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b122",
+              "@id": "_:b8",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b123",
+                "@id": "_:b9",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -483,40 +480,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test004-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b286",
+              "@id": "_:b172",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b287",
+                "@id": "_:b173",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b7",
+              "@id": "_:b290",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b8",
+                "@id": "_:b291",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b124",
+              "@id": "_:b10",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b125",
+                "@id": "_:b11",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -539,38 +535,38 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test004-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b400",
+              "@id": "_:b294",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004m",
               "result": {
-                "@id": "_:b401",
+                "@id": "_:b295",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b398",
+              "@id": "_:b292",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004m",
               "result": {
-                "@id": "_:b399",
+                "@id": "_:b293",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b126",
+              "@id": "_:b12",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b127",
+                "@id": "_:b13",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -593,40 +589,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test005-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b288",
+              "@id": "_:b174",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b289",
+                "@id": "_:b175",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b9",
+              "@id": "_:b296",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b10",
+                "@id": "_:b297",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b128",
+              "@id": "_:b14",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b129",
+                "@id": "_:b15",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -649,38 +644,38 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test005-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b404",
+              "@id": "_:b300",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005m",
               "result": {
-                "@id": "_:b405",
+                "@id": "_:b301",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b402",
+              "@id": "_:b298",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005m",
               "result": {
-                "@id": "_:b403",
+                "@id": "_:b299",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b130",
+              "@id": "_:b16",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b131",
+                "@id": "_:b17",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -703,40 +698,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test006-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b290",
+              "@id": "_:b176",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test006c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b291",
+                "@id": "_:b177",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b11",
+              "@id": "_:b302",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test006c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b12",
+                "@id": "_:b303",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b132",
+              "@id": "_:b18",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test006c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b133",
+                "@id": "_:b19",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -759,40 +753,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test008-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b292",
+              "@id": "_:b178",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test008c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b293",
+                "@id": "_:b179",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b13",
+              "@id": "_:b304",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test008c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b14",
+                "@id": "_:b305",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b134",
+              "@id": "_:b20",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test008c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b135",
+                "@id": "_:b21",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -815,40 +808,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test009-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b294",
+              "@id": "_:b180",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test009c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b295",
+                "@id": "_:b181",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b15",
+              "@id": "_:b306",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test009c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b16",
+                "@id": "_:b307",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b136",
+              "@id": "_:b22",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test009c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b137",
+                "@id": "_:b23",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -871,40 +863,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test010-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b296",
+              "@id": "_:b182",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test010c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b297",
+                "@id": "_:b183",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b17",
+              "@id": "_:b308",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test010c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b18",
+                "@id": "_:b309",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b138",
+              "@id": "_:b24",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test010c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b139",
+                "@id": "_:b25",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -927,40 +918,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test011-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b298",
+              "@id": "_:b184",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test011c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b299",
+                "@id": "_:b185",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b19",
+              "@id": "_:b310",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test011c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b20",
+                "@id": "_:b311",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b140",
+              "@id": "_:b26",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test011c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b141",
+                "@id": "_:b27",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -983,40 +973,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test013-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b300",
+              "@id": "_:b186",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test013c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b301",
+                "@id": "_:b187",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b21",
+              "@id": "_:b312",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test013c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b22",
+                "@id": "_:b313",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b142",
+              "@id": "_:b28",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test013c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b143",
+                "@id": "_:b29",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1039,40 +1028,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test014-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b302",
+              "@id": "_:b188",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test014c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b303",
+                "@id": "_:b189",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b23",
+              "@id": "_:b314",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test014c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b24",
+                "@id": "_:b315",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b144",
+              "@id": "_:b30",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test014c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b145",
+                "@id": "_:b31",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1095,40 +1083,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test016-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b304",
+              "@id": "_:b190",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b305",
+                "@id": "_:b191",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b25",
+              "@id": "_:b316",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b26",
+                "@id": "_:b317",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b146",
+              "@id": "_:b32",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b147",
+                "@id": "_:b33",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1151,38 +1138,38 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test016-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b408",
+              "@id": "_:b320",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016m",
               "result": {
-                "@id": "_:b409",
+                "@id": "_:b321",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b406",
+              "@id": "_:b318",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016m",
               "result": {
-                "@id": "_:b407",
+                "@id": "_:b319",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b148",
+              "@id": "_:b34",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b149",
+                "@id": "_:b35",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1205,40 +1192,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test017-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b306",
+              "@id": "_:b192",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b307",
+                "@id": "_:b193",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b27",
+              "@id": "_:b322",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b28",
+                "@id": "_:b323",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b150",
+              "@id": "_:b36",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b151",
+                "@id": "_:b37",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1261,38 +1247,38 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test017-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b412",
+              "@id": "_:b326",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017m",
               "result": {
-                "@id": "_:b413",
+                "@id": "_:b327",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b410",
+              "@id": "_:b324",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017m",
               "result": {
-                "@id": "_:b411",
+                "@id": "_:b325",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b152",
+              "@id": "_:b38",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b153",
+                "@id": "_:b39",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1315,40 +1301,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test018-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b308",
+              "@id": "_:b194",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b309",
+                "@id": "_:b195",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b29",
+              "@id": "_:b328",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b30",
+                "@id": "_:b329",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b154",
+              "@id": "_:b40",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b155",
+                "@id": "_:b41",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1371,38 +1356,38 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test018-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b416",
+              "@id": "_:b332",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018m",
               "result": {
-                "@id": "_:b417",
+                "@id": "_:b333",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b414",
+              "@id": "_:b330",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018m",
               "result": {
-                "@id": "_:b415",
+                "@id": "_:b331",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b156",
+              "@id": "_:b42",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b157",
+                "@id": "_:b43",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1425,40 +1410,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test019-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b310",
+              "@id": "_:b196",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test019c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b311",
+                "@id": "_:b197",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b31",
+              "@id": "_:b334",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test019c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b32",
+                "@id": "_:b335",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b158",
+              "@id": "_:b44",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test019c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b159",
+                "@id": "_:b45",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1481,40 +1465,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test020-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b312",
+              "@id": "_:b198",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b313",
+                "@id": "_:b199",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b33",
+              "@id": "_:b336",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b34",
+                "@id": "_:b337",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b160",
+              "@id": "_:b46",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b161",
+                "@id": "_:b47",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1537,38 +1520,38 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test020-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b420",
+              "@id": "_:b340",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020m",
               "result": {
-                "@id": "_:b421",
+                "@id": "_:b341",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b418",
+              "@id": "_:b338",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020m",
               "result": {
-                "@id": "_:b419",
+                "@id": "_:b339",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b162",
+              "@id": "_:b48",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b163",
+                "@id": "_:b49",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1591,40 +1574,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test021-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b314",
+              "@id": "_:b200",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test021c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b315",
+                "@id": "_:b201",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b35",
+              "@id": "_:b342",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test021c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b36",
+                "@id": "_:b343",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b164",
+              "@id": "_:b50",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test021c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b165",
+                "@id": "_:b51",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1647,40 +1629,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test022-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b316",
+              "@id": "_:b202",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test022c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b317",
+                "@id": "_:b203",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b37",
+              "@id": "_:b344",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test022c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b38",
+                "@id": "_:b345",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b166",
+              "@id": "_:b52",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test022c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b167",
+                "@id": "_:b53",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1703,40 +1684,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test023-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b318",
+              "@id": "_:b204",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test023c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b319",
+                "@id": "_:b205",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b39",
+              "@id": "_:b346",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test023c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b40",
+                "@id": "_:b347",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b168",
+              "@id": "_:b54",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test023c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b169",
+                "@id": "_:b55",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1759,40 +1739,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test024-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b320",
+              "@id": "_:b206",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test024c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b321",
+                "@id": "_:b207",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b41",
+              "@id": "_:b348",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test024c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b42",
+                "@id": "_:b349",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b170",
+              "@id": "_:b56",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test024c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b171",
+                "@id": "_:b57",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1815,40 +1794,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test025-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b322",
+              "@id": "_:b208",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test025c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b323",
+                "@id": "_:b209",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b43",
+              "@id": "_:b350",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test025c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b44",
+                "@id": "_:b351",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b172",
+              "@id": "_:b58",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test025c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b173",
+                "@id": "_:b59",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1871,40 +1849,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test026-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b324",
+              "@id": "_:b210",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test026c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b325",
+                "@id": "_:b211",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b45",
+              "@id": "_:b352",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test026c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b46",
+                "@id": "_:b353",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b174",
+              "@id": "_:b60",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test026c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b175",
+                "@id": "_:b61",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1927,40 +1904,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test027-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b326",
+              "@id": "_:b212",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test027c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b327",
+                "@id": "_:b213",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b47",
+              "@id": "_:b354",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test027c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b48",
+                "@id": "_:b355",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b176",
+              "@id": "_:b62",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test027c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b177",
+                "@id": "_:b63",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1983,40 +1959,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test028-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b328",
+              "@id": "_:b214",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test028c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b329",
+                "@id": "_:b215",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b49",
+              "@id": "_:b356",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test028c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b50",
+                "@id": "_:b357",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b178",
+              "@id": "_:b64",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test028c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b179",
+                "@id": "_:b65",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2039,40 +2014,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test029-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b330",
+              "@id": "_:b216",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test029c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b331",
+                "@id": "_:b217",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b51",
+              "@id": "_:b358",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test029c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b52",
+                "@id": "_:b359",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b180",
+              "@id": "_:b66",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test029c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b181",
+                "@id": "_:b67",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2095,40 +2069,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test030-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b332",
+              "@id": "_:b218",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b333",
+                "@id": "_:b219",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b53",
+              "@id": "_:b360",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b54",
+                "@id": "_:b361",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b182",
+              "@id": "_:b68",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b183",
+                "@id": "_:b69",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2151,38 +2124,38 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test030-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b424",
+              "@id": "_:b364",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030m",
               "result": {
-                "@id": "_:b425",
+                "@id": "_:b365",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b422",
+              "@id": "_:b362",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030m",
               "result": {
-                "@id": "_:b423",
+                "@id": "_:b363",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b184",
+              "@id": "_:b70",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b185",
+                "@id": "_:b71",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2205,40 +2178,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test033-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b334",
+              "@id": "_:b220",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test033c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b335",
+                "@id": "_:b221",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b55",
+              "@id": "_:b366",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test033c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b56",
+                "@id": "_:b367",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b186",
+              "@id": "_:b72",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test033c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b187",
+                "@id": "_:b73",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2261,40 +2233,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test034-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b336",
+              "@id": "_:b222",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test034c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b337",
+                "@id": "_:b223",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b57",
+              "@id": "_:b368",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test034c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b58",
+                "@id": "_:b369",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b188",
+              "@id": "_:b74",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test034c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b189",
+                "@id": "_:b75",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2317,40 +2288,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test035-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b338",
+              "@id": "_:b224",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test035c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b339",
+                "@id": "_:b225",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b59",
+              "@id": "_:b370",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test035c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b60",
+                "@id": "_:b371",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b190",
+              "@id": "_:b76",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test035c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b191",
+                "@id": "_:b77",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2373,40 +2343,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test036-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b340",
+              "@id": "_:b226",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test036c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b341",
+                "@id": "_:b227",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b61",
+              "@id": "_:b372",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test036c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b62",
+                "@id": "_:b373",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b192",
+              "@id": "_:b78",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test036c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b193",
+                "@id": "_:b79",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2429,40 +2398,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test038-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b342",
+              "@id": "_:b228",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test038c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b343",
+                "@id": "_:b229",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b63",
+              "@id": "_:b374",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test038c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b64",
+                "@id": "_:b375",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b194",
+              "@id": "_:b80",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test038c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b195",
+                "@id": "_:b81",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2485,40 +2453,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test039-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b344",
+              "@id": "_:b230",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test039c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b345",
+                "@id": "_:b231",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b65",
+              "@id": "_:b376",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test039c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b66",
+                "@id": "_:b377",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b196",
+              "@id": "_:b82",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test039c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b197",
+                "@id": "_:b83",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2541,40 +2508,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test040-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b346",
+              "@id": "_:b232",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test040c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b347",
+                "@id": "_:b233",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b67",
+              "@id": "_:b378",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test040c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b68",
+                "@id": "_:b379",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b198",
+              "@id": "_:b84",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test040c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b199",
+                "@id": "_:b85",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2597,40 +2563,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test043-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b348",
+              "@id": "_:b234",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test043c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b349",
+                "@id": "_:b235",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b69",
+              "@id": "_:b380",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test043c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b70",
+                "@id": "_:b381",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b200",
+              "@id": "_:b86",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test043c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b201",
+                "@id": "_:b87",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2654,40 +2619,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test044-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b350",
+              "@id": "_:b236",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test044c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b351",
+                "@id": "_:b237",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b71",
+              "@id": "_:b382",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test044c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b72",
+                "@id": "_:b383",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b202",
+              "@id": "_:b88",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test044c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b203",
+                "@id": "_:b89",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2711,40 +2675,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test045-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b352",
+              "@id": "_:b238",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test045c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b353",
+                "@id": "_:b239",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b73",
+              "@id": "_:b384",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test045c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b74",
+                "@id": "_:b385",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b204",
+              "@id": "_:b90",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test045c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b205",
+                "@id": "_:b91",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2768,40 +2731,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test046-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b354",
+              "@id": "_:b240",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test046c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b355",
+                "@id": "_:b241",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b75",
+              "@id": "_:b386",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test046c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b76",
+                "@id": "_:b387",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b206",
+              "@id": "_:b92",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test046c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b207",
+                "@id": "_:b93",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2824,40 +2786,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test047-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b356",
+              "@id": "_:b242",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b357",
+                "@id": "_:b243",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b77",
+              "@id": "_:b388",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b78",
+                "@id": "_:b389",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b208",
+              "@id": "_:b94",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b209",
+                "@id": "_:b95",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2880,38 +2841,38 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test047-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b428",
+              "@id": "_:b392",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047m",
               "result": {
-                "@id": "_:b429",
+                "@id": "_:b393",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b426",
+              "@id": "_:b390",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047m",
               "result": {
-                "@id": "_:b427",
+                "@id": "_:b391",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b210",
+              "@id": "_:b96",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b211",
+                "@id": "_:b97",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2934,40 +2895,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test048-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b358",
+              "@id": "_:b244",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b359",
+                "@id": "_:b245",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b79",
+              "@id": "_:b394",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b80",
+                "@id": "_:b395",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b212",
+              "@id": "_:b98",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b213",
+                "@id": "_:b99",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2990,38 +2950,38 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test048-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b432",
+              "@id": "_:b398",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048m",
               "result": {
-                "@id": "_:b433",
+                "@id": "_:b399",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b430",
+              "@id": "_:b396",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048m",
               "result": {
-                "@id": "_:b431",
+                "@id": "_:b397",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b214",
+              "@id": "_:b100",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b215",
+                "@id": "_:b101",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3044,40 +3004,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test053-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b360",
+              "@id": "_:b246",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b361",
+                "@id": "_:b247",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b81",
+              "@id": "_:b400",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b82",
+                "@id": "_:b401",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b216",
+              "@id": "_:b102",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b217",
+                "@id": "_:b103",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3100,38 +3059,38 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test053-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b436",
+              "@id": "_:b404",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053m",
               "result": {
-                "@id": "_:b437",
+                "@id": "_:b405",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b434",
+              "@id": "_:b402",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053m",
               "result": {
-                "@id": "_:b435",
+                "@id": "_:b403",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b218",
+              "@id": "_:b104",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b219",
+                "@id": "_:b105",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3154,40 +3113,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test054-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b362",
+              "@id": "_:b248",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test054c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b363",
+                "@id": "_:b249",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b83",
+              "@id": "_:b406",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test054c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b84",
+                "@id": "_:b407",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b220",
+              "@id": "_:b106",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test054c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b221",
+                "@id": "_:b107",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3210,40 +3168,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test055-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b364",
+              "@id": "_:b250",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b365",
+                "@id": "_:b251",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b85",
+              "@id": "_:b408",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b86",
+                "@id": "_:b409",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b222",
+              "@id": "_:b108",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b223",
+                "@id": "_:b109",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3266,38 +3223,38 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test055-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b440",
+              "@id": "_:b412",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055m",
               "result": {
-                "@id": "_:b441",
+                "@id": "_:b413",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b438",
+              "@id": "_:b410",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055m",
               "result": {
-                "@id": "_:b439",
+                "@id": "_:b411",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b224",
+              "@id": "_:b110",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b225",
+                "@id": "_:b111",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3320,40 +3277,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test056-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b366",
+              "@id": "_:b252",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b367",
+                "@id": "_:b253",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b87",
+              "@id": "_:b414",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b88",
+                "@id": "_:b415",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b226",
+              "@id": "_:b112",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b227",
+                "@id": "_:b113",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3376,38 +3332,38 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test056-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b444",
+              "@id": "_:b418",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056m",
               "result": {
-                "@id": "_:b445",
+                "@id": "_:b419",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b442",
+              "@id": "_:b416",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056m",
               "result": {
-                "@id": "_:b443",
+                "@id": "_:b417",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b228",
+              "@id": "_:b114",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b229",
+                "@id": "_:b115",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3430,40 +3386,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test057-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b368",
+              "@id": "_:b254",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b369",
+                "@id": "_:b255",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b89",
+              "@id": "_:b420",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b90",
+                "@id": "_:b421",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b230",
+              "@id": "_:b116",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b231",
+                "@id": "_:b117",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3486,38 +3441,38 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test057-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b448",
+              "@id": "_:b424",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057m",
               "result": {
-                "@id": "_:b449",
+                "@id": "_:b425",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b446",
+              "@id": "_:b422",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057m",
               "result": {
-                "@id": "_:b447",
+                "@id": "_:b423",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b232",
+              "@id": "_:b118",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b233",
+                "@id": "_:b119",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3540,40 +3495,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test058-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b370",
+              "@id": "_:b256",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test058c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b371",
+                "@id": "_:b257",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b91",
+              "@id": "_:b426",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test058c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b92",
+                "@id": "_:b427",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b234",
+              "@id": "_:b120",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test058c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b235",
+                "@id": "_:b121",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3596,40 +3550,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test059-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b372",
+              "@id": "_:b258",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test059c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b373",
+                "@id": "_:b259",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b93",
+              "@id": "_:b428",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test059c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b94",
+                "@id": "_:b429",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b236",
+              "@id": "_:b122",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test059c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b237",
+                "@id": "_:b123",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3652,40 +3605,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test060-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b374",
+              "@id": "_:b260",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b375",
+                "@id": "_:b261",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b95",
+              "@id": "_:b430",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b96",
+                "@id": "_:b431",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b238",
+              "@id": "_:b124",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b239",
+                "@id": "_:b125",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3708,38 +3660,38 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test060-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b452",
+              "@id": "_:b434",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060m",
               "result": {
-                "@id": "_:b453",
+                "@id": "_:b435",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b450",
+              "@id": "_:b432",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060m",
               "result": {
-                "@id": "_:b451",
+                "@id": "_:b433",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b240",
+              "@id": "_:b126",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b241",
+                "@id": "_:b127",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3762,40 +3714,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test061-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b376",
+              "@id": "_:b262",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test061c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b377",
+                "@id": "_:b263",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b97",
+              "@id": "_:b436",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test061c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b98",
+                "@id": "_:b437",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b242",
+              "@id": "_:b128",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test061c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b243",
+                "@id": "_:b129",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3818,40 +3769,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test062-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b378",
+              "@id": "_:b264",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test062c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b379",
+                "@id": "_:b265",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b99",
+              "@id": "_:b438",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test062c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b100",
+                "@id": "_:b439",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b244",
+              "@id": "_:b130",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test062c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b245",
+                "@id": "_:b131",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3875,40 +3825,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test063-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b380",
+              "@id": "_:b266",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b381",
+                "@id": "_:b267",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b101",
+              "@id": "_:b440",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b102",
+                "@id": "_:b441",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b246",
+              "@id": "_:b132",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b247",
+                "@id": "_:b133",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3932,38 +3881,38 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test063-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b456",
+              "@id": "_:b444",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063m",
               "result": {
-                "@id": "_:b457",
+                "@id": "_:b445",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b454",
+              "@id": "_:b442",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063m",
               "result": {
-                "@id": "_:b455",
+                "@id": "_:b443",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b248",
+              "@id": "_:b134",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b249",
+                "@id": "_:b135",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3986,40 +3935,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test064-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b382",
+              "@id": "_:b268",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test064c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b383",
+                "@id": "_:b269",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b103",
+              "@id": "_:b446",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test064c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b104",
+                "@id": "_:b447",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b250",
+              "@id": "_:b136",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test064c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b251",
+                "@id": "_:b137",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4042,40 +3990,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test065-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b384",
+              "@id": "_:b270",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test065c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b385",
+                "@id": "_:b271",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b105",
+              "@id": "_:b448",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test065c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b106",
+                "@id": "_:b449",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b252",
+              "@id": "_:b138",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test065c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b253",
+                "@id": "_:b139",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4098,40 +4045,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test066-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b386",
+              "@id": "_:b272",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test066c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b387",
+                "@id": "_:b273",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b107",
+              "@id": "_:b450",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test066c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b108",
+                "@id": "_:b451",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b254",
+              "@id": "_:b140",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test066c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b255",
+                "@id": "_:b141",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4154,40 +4100,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test067-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b388",
+              "@id": "_:b274",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test067c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b389",
+                "@id": "_:b275",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b109",
+              "@id": "_:b452",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test067c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b110",
+                "@id": "_:b453",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b256",
+              "@id": "_:b142",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test067c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b257",
+                "@id": "_:b143",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4210,40 +4155,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test068-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b390",
+              "@id": "_:b276",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test068c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b391",
+                "@id": "_:b277",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b111",
+              "@id": "_:b454",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test068c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b112",
+                "@id": "_:b455",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b258",
+              "@id": "_:b144",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test068c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b259",
+                "@id": "_:b145",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4266,40 +4210,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test069-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b392",
+              "@id": "_:b278",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test069c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b393",
+                "@id": "_:b279",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b113",
+              "@id": "_:b456",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test069c",
-              "assertedBy": "https://www.ivan-herman.net/foaf#me",
-              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b114",
+                "@id": "_:b457",
                 "@type": "TestResult",
-                "outcome": "earl:passed"
-              }
+                "outcome": "earl:untested"
+              },
+              "assertedBy": null
             },
             {
-              "@id": "_:b260",
+              "@id": "_:b146",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test069c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b261",
+                "@id": "_:b147",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4347,14 +4290,14 @@
               "assertedBy": null
             },
             {
-              "@id": "_:b262",
+              "@id": "_:b148",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test070c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b263",
+                "@id": "_:b149",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4402,14 +4345,14 @@
               "assertedBy": null
             },
             {
-              "@id": "_:b264",
+              "@id": "_:b150",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test070m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b265",
+                "@id": "_:b151",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4457,14 +4400,14 @@
               "assertedBy": null
             },
             {
-              "@id": "_:b266",
+              "@id": "_:b152",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test071c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b267",
+                "@id": "_:b153",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4512,14 +4455,14 @@
               "assertedBy": null
             },
             {
-              "@id": "_:b268",
+              "@id": "_:b154",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test071m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b269",
+                "@id": "_:b155",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4567,14 +4510,14 @@
               "assertedBy": null
             },
             {
-              "@id": "_:b270",
+              "@id": "_:b156",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test072c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b271",
+                "@id": "_:b157",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4622,14 +4565,14 @@
               "assertedBy": null
             },
             {
-              "@id": "_:b272",
+              "@id": "_:b158",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test072m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b273",
+                "@id": "_:b159",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4677,14 +4620,14 @@
               "assertedBy": null
             },
             {
-              "@id": "_:b274",
+              "@id": "_:b160",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test073c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b275",
+                "@id": "_:b161",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4732,14 +4675,14 @@
               "assertedBy": null
             },
             {
-              "@id": "_:b276",
+              "@id": "_:b162",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test073m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b277",
+                "@id": "_:b163",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4786,14 +4729,14 @@
               "assertedBy": null
             },
             {
-              "@id": "_:b278",
+              "@id": "_:b164",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test074c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b279",
+                "@id": "_:b165",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }

--- a/reports/earl.jsonld
+++ b/reports/earl.jsonld
@@ -135,7 +135,7 @@
       "name": "earl-report-0.8.0",
       "doap:created": {
         "@type": "http://www.w3.org/2001/XMLSchema#date",
-        "@value": "2023-07-05"
+        "@value": "2023-07-10"
       },
       "revision": "0.8.0"
     },
@@ -230,7 +230,7 @@
       "doapDesc": "RDF::Normalize performs Dataset Canonicalization for RDF.rb.",
       "language": "Ruby",
       "release": {
-        "@id": "_:b1",
+        "@id": "_:b165",
         "revision": "0.6.0"
       }
     }
@@ -261,39 +261,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test001-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b166",
+              "@id": "_:b330",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test001c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b167",
+                "@id": "_:b331",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b280",
+              "@id": "_:b1",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test001c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b281",
+                "@id": "_:b2",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b2",
+              "@id": "_:b166",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test001c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b3",
+                "@id": "_:b167",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -316,39 +317,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test002-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b168",
+              "@id": "_:b332",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test002c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b169",
+                "@id": "_:b333",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b282",
+              "@id": "_:b3",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test002c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b283",
+                "@id": "_:b4",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b4",
+              "@id": "_:b168",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test002c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b5",
+                "@id": "_:b169",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -371,39 +373,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test003-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b170",
+              "@id": "_:b334",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b171",
+                "@id": "_:b335",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b284",
+              "@id": "_:b5",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b285",
+                "@id": "_:b6",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b6",
+              "@id": "_:b170",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b7",
+                "@id": "_:b171",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -426,38 +429,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test003-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b288",
+              "@id": "_:b444",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003m",
               "result": {
-                "@id": "_:b289",
+                "@id": "_:b445",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b286",
+              "@id": "_:b7",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b287",
+                "@id": "_:b8",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b8",
+              "@id": "_:b172",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b9",
+                "@id": "_:b173",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -480,39 +484,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test004-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b172",
+              "@id": "_:b336",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b173",
+                "@id": "_:b337",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b290",
+              "@id": "_:b9",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b291",
+                "@id": "_:b10",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b10",
+              "@id": "_:b174",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b11",
+                "@id": "_:b175",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -535,38 +540,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test004-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b294",
+              "@id": "_:b446",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004m",
               "result": {
-                "@id": "_:b295",
+                "@id": "_:b447",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b292",
+              "@id": "_:b11",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b293",
+                "@id": "_:b12",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b12",
+              "@id": "_:b176",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b13",
+                "@id": "_:b177",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -589,39 +595,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test005-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b174",
+              "@id": "_:b338",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b175",
+                "@id": "_:b339",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b296",
+              "@id": "_:b13",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b297",
+                "@id": "_:b14",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b14",
+              "@id": "_:b178",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b15",
+                "@id": "_:b179",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -644,38 +651,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test005-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b300",
+              "@id": "_:b448",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005m",
               "result": {
-                "@id": "_:b301",
+                "@id": "_:b449",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b298",
+              "@id": "_:b15",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b299",
+                "@id": "_:b16",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b16",
+              "@id": "_:b180",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b17",
+                "@id": "_:b181",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -698,39 +706,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test006-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b176",
+              "@id": "_:b340",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test006c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b177",
+                "@id": "_:b341",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b302",
+              "@id": "_:b17",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test006c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b303",
+                "@id": "_:b18",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b18",
+              "@id": "_:b182",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test006c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b19",
+                "@id": "_:b183",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -753,39 +762,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test008-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b178",
+              "@id": "_:b342",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test008c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b179",
+                "@id": "_:b343",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b304",
+              "@id": "_:b19",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test008c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b305",
+                "@id": "_:b20",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b20",
+              "@id": "_:b184",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test008c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b21",
+                "@id": "_:b185",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -808,39 +818,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test009-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b180",
+              "@id": "_:b344",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test009c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b181",
+                "@id": "_:b345",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b306",
+              "@id": "_:b21",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test009c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b307",
+                "@id": "_:b22",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b22",
+              "@id": "_:b186",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test009c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b23",
+                "@id": "_:b187",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -863,39 +874,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test010-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b182",
+              "@id": "_:b346",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test010c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b183",
+                "@id": "_:b347",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b308",
+              "@id": "_:b23",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test010c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b309",
+                "@id": "_:b24",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b24",
+              "@id": "_:b188",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test010c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b25",
+                "@id": "_:b189",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -918,39 +930,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test011-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b184",
+              "@id": "_:b348",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test011c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b185",
+                "@id": "_:b349",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b310",
+              "@id": "_:b25",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test011c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b311",
+                "@id": "_:b26",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b26",
+              "@id": "_:b190",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test011c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b27",
+                "@id": "_:b191",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -973,39 +986,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test013-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b186",
+              "@id": "_:b350",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test013c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b187",
+                "@id": "_:b351",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b312",
+              "@id": "_:b27",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test013c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b313",
+                "@id": "_:b28",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b28",
+              "@id": "_:b192",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test013c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b29",
+                "@id": "_:b193",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1028,39 +1042,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test014-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b188",
+              "@id": "_:b352",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test014c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b189",
+                "@id": "_:b353",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b314",
+              "@id": "_:b29",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test014c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b315",
+                "@id": "_:b30",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b30",
+              "@id": "_:b194",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test014c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b31",
+                "@id": "_:b195",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1083,39 +1098,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test016-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b190",
+              "@id": "_:b354",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b191",
+                "@id": "_:b355",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b316",
+              "@id": "_:b31",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b317",
+                "@id": "_:b32",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b32",
+              "@id": "_:b196",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b33",
+                "@id": "_:b197",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1138,38 +1154,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test016-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b320",
+              "@id": "_:b450",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016m",
               "result": {
-                "@id": "_:b321",
+                "@id": "_:b451",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b318",
+              "@id": "_:b33",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b319",
+                "@id": "_:b34",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b34",
+              "@id": "_:b198",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b35",
+                "@id": "_:b199",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1192,39 +1209,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test017-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b192",
+              "@id": "_:b356",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b193",
+                "@id": "_:b357",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b322",
+              "@id": "_:b35",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b323",
+                "@id": "_:b36",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b36",
+              "@id": "_:b200",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b37",
+                "@id": "_:b201",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1247,38 +1265,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test017-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b326",
+              "@id": "_:b452",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017m",
               "result": {
-                "@id": "_:b327",
+                "@id": "_:b453",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b324",
+              "@id": "_:b37",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b325",
+                "@id": "_:b38",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b38",
+              "@id": "_:b202",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b39",
+                "@id": "_:b203",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1301,39 +1320,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test018-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b194",
+              "@id": "_:b358",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b195",
+                "@id": "_:b359",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b328",
+              "@id": "_:b39",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b329",
+                "@id": "_:b40",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b40",
+              "@id": "_:b204",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b41",
+                "@id": "_:b205",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1356,38 +1376,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test018-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b332",
+              "@id": "_:b454",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018m",
               "result": {
-                "@id": "_:b333",
+                "@id": "_:b455",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b330",
+              "@id": "_:b41",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b331",
+                "@id": "_:b42",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b42",
+              "@id": "_:b206",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b43",
+                "@id": "_:b207",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1410,39 +1431,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test019-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b196",
+              "@id": "_:b360",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test019c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b197",
+                "@id": "_:b361",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b334",
+              "@id": "_:b43",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test019c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b335",
+                "@id": "_:b44",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b44",
+              "@id": "_:b208",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test019c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b45",
+                "@id": "_:b209",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1465,39 +1487,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test020-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b198",
+              "@id": "_:b362",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b199",
+                "@id": "_:b363",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b336",
+              "@id": "_:b45",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b337",
+                "@id": "_:b46",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b46",
+              "@id": "_:b210",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b47",
+                "@id": "_:b211",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1520,38 +1543,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test020-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b340",
+              "@id": "_:b456",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020m",
               "result": {
-                "@id": "_:b341",
+                "@id": "_:b457",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b338",
+              "@id": "_:b47",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b339",
+                "@id": "_:b48",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b48",
+              "@id": "_:b212",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b49",
+                "@id": "_:b213",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1574,39 +1598,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test021-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b200",
+              "@id": "_:b364",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test021c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b201",
+                "@id": "_:b365",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b342",
+              "@id": "_:b49",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test021c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b343",
+                "@id": "_:b50",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b50",
+              "@id": "_:b214",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test021c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b51",
+                "@id": "_:b215",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1629,39 +1654,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test022-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b202",
+              "@id": "_:b366",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test022c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b203",
+                "@id": "_:b367",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b344",
+              "@id": "_:b51",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test022c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b345",
+                "@id": "_:b52",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b52",
+              "@id": "_:b216",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test022c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b53",
+                "@id": "_:b217",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1684,39 +1710,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test023-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b204",
+              "@id": "_:b368",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test023c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b205",
+                "@id": "_:b369",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b346",
+              "@id": "_:b53",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test023c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b347",
+                "@id": "_:b54",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b54",
+              "@id": "_:b218",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test023c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b55",
+                "@id": "_:b219",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1739,39 +1766,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test024-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b206",
+              "@id": "_:b370",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test024c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b207",
+                "@id": "_:b371",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b348",
+              "@id": "_:b55",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test024c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b349",
+                "@id": "_:b56",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b56",
+              "@id": "_:b220",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test024c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b57",
+                "@id": "_:b221",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1794,39 +1822,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test025-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b208",
+              "@id": "_:b372",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test025c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b209",
+                "@id": "_:b373",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b350",
+              "@id": "_:b57",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test025c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b351",
+                "@id": "_:b58",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b58",
+              "@id": "_:b222",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test025c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b59",
+                "@id": "_:b223",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1849,39 +1878,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test026-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b210",
+              "@id": "_:b374",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test026c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b211",
+                "@id": "_:b375",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b352",
+              "@id": "_:b59",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test026c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b353",
+                "@id": "_:b60",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b60",
+              "@id": "_:b224",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test026c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b61",
+                "@id": "_:b225",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1904,39 +1934,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test027-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b212",
+              "@id": "_:b376",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test027c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b213",
+                "@id": "_:b377",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b354",
+              "@id": "_:b61",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test027c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b355",
+                "@id": "_:b62",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b62",
+              "@id": "_:b226",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test027c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b63",
+                "@id": "_:b227",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1959,39 +1990,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test028-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b214",
+              "@id": "_:b378",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test028c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b215",
+                "@id": "_:b379",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b356",
+              "@id": "_:b63",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test028c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b357",
+                "@id": "_:b64",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b64",
+              "@id": "_:b228",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test028c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b65",
+                "@id": "_:b229",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2014,39 +2046,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test029-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b216",
+              "@id": "_:b380",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test029c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b217",
+                "@id": "_:b381",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b358",
+              "@id": "_:b65",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test029c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b359",
+                "@id": "_:b66",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b66",
+              "@id": "_:b230",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test029c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b67",
+                "@id": "_:b231",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2069,39 +2102,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test030-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b218",
+              "@id": "_:b382",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b219",
+                "@id": "_:b383",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b360",
+              "@id": "_:b67",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b361",
+                "@id": "_:b68",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b68",
+              "@id": "_:b232",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b69",
+                "@id": "_:b233",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2124,38 +2158,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test030-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b364",
+              "@id": "_:b458",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030m",
               "result": {
-                "@id": "_:b365",
+                "@id": "_:b459",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b362",
+              "@id": "_:b69",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b363",
+                "@id": "_:b70",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b70",
+              "@id": "_:b234",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b71",
+                "@id": "_:b235",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2178,39 +2213,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test033-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b220",
+              "@id": "_:b384",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test033c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b221",
+                "@id": "_:b385",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b366",
+              "@id": "_:b71",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test033c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b367",
+                "@id": "_:b72",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b72",
+              "@id": "_:b236",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test033c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b73",
+                "@id": "_:b237",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2233,39 +2269,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test034-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b222",
+              "@id": "_:b386",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test034c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b223",
+                "@id": "_:b387",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b368",
+              "@id": "_:b73",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test034c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b369",
+                "@id": "_:b74",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b74",
+              "@id": "_:b238",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test034c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b75",
+                "@id": "_:b239",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2288,39 +2325,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test035-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b224",
+              "@id": "_:b388",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test035c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b225",
+                "@id": "_:b389",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b370",
+              "@id": "_:b75",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test035c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b371",
+                "@id": "_:b76",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b76",
+              "@id": "_:b240",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test035c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b77",
+                "@id": "_:b241",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2343,39 +2381,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test036-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b226",
+              "@id": "_:b390",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test036c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b227",
+                "@id": "_:b391",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b372",
+              "@id": "_:b77",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test036c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b373",
+                "@id": "_:b78",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b78",
+              "@id": "_:b242",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test036c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b79",
+                "@id": "_:b243",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2398,39 +2437,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test038-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b228",
+              "@id": "_:b392",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test038c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b229",
+                "@id": "_:b393",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b374",
+              "@id": "_:b79",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test038c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b375",
+                "@id": "_:b80",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b80",
+              "@id": "_:b244",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test038c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b81",
+                "@id": "_:b245",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2453,39 +2493,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test039-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b230",
+              "@id": "_:b394",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test039c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b231",
+                "@id": "_:b395",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b376",
+              "@id": "_:b81",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test039c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b377",
+                "@id": "_:b82",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b82",
+              "@id": "_:b246",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test039c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b83",
+                "@id": "_:b247",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2508,39 +2549,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test040-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b232",
+              "@id": "_:b396",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test040c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b233",
+                "@id": "_:b397",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b378",
+              "@id": "_:b83",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test040c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b379",
+                "@id": "_:b84",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b84",
+              "@id": "_:b248",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test040c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b85",
+                "@id": "_:b249",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2563,39 +2605,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test043-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b234",
+              "@id": "_:b398",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test043c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b235",
+                "@id": "_:b399",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b380",
+              "@id": "_:b85",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test043c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b381",
+                "@id": "_:b86",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b86",
+              "@id": "_:b250",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test043c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b87",
+                "@id": "_:b251",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2619,39 +2662,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test044-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b236",
+              "@id": "_:b400",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test044c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b237",
+                "@id": "_:b401",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b382",
+              "@id": "_:b87",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test044c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b383",
+                "@id": "_:b88",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b88",
+              "@id": "_:b252",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test044c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b89",
+                "@id": "_:b253",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2675,39 +2719,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test045-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b238",
+              "@id": "_:b402",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test045c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b239",
+                "@id": "_:b403",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b384",
+              "@id": "_:b89",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test045c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b385",
+                "@id": "_:b90",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b90",
+              "@id": "_:b254",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test045c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b91",
+                "@id": "_:b255",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2731,39 +2776,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test046-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b240",
+              "@id": "_:b404",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test046c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b241",
+                "@id": "_:b405",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b386",
+              "@id": "_:b91",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test046c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b387",
+                "@id": "_:b92",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b92",
+              "@id": "_:b256",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test046c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b93",
+                "@id": "_:b257",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2786,39 +2832,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test047-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b242",
+              "@id": "_:b406",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b243",
+                "@id": "_:b407",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b388",
+              "@id": "_:b93",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b389",
+                "@id": "_:b94",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b94",
+              "@id": "_:b258",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b95",
+                "@id": "_:b259",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2841,38 +2888,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test047-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b392",
+              "@id": "_:b460",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047m",
               "result": {
-                "@id": "_:b393",
+                "@id": "_:b461",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b390",
+              "@id": "_:b95",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b391",
+                "@id": "_:b96",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b96",
+              "@id": "_:b260",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b97",
+                "@id": "_:b261",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2895,39 +2943,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test048-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b244",
+              "@id": "_:b408",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b245",
+                "@id": "_:b409",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b394",
+              "@id": "_:b97",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b395",
+                "@id": "_:b98",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b98",
+              "@id": "_:b262",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b99",
+                "@id": "_:b263",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2950,38 +2999,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test048-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b398",
+              "@id": "_:b462",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048m",
               "result": {
-                "@id": "_:b399",
+                "@id": "_:b463",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b396",
+              "@id": "_:b99",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b397",
+                "@id": "_:b100",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b100",
+              "@id": "_:b264",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b101",
+                "@id": "_:b265",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3004,39 +3054,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test053-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b246",
+              "@id": "_:b410",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b247",
+                "@id": "_:b411",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b400",
+              "@id": "_:b101",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b401",
+                "@id": "_:b102",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b102",
+              "@id": "_:b266",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b103",
+                "@id": "_:b267",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3059,38 +3110,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test053-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b404",
+              "@id": "_:b464",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053m",
               "result": {
-                "@id": "_:b405",
+                "@id": "_:b465",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b402",
+              "@id": "_:b103",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b403",
+                "@id": "_:b104",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b104",
+              "@id": "_:b268",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b105",
+                "@id": "_:b269",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3113,39 +3165,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test054-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b248",
+              "@id": "_:b412",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test054c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b249",
+                "@id": "_:b413",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b406",
+              "@id": "_:b105",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test054c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b407",
+                "@id": "_:b106",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b106",
+              "@id": "_:b270",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test054c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b107",
+                "@id": "_:b271",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3168,39 +3221,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test055-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b250",
+              "@id": "_:b414",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b251",
+                "@id": "_:b415",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b408",
+              "@id": "_:b107",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b409",
+                "@id": "_:b108",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b108",
+              "@id": "_:b272",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b109",
+                "@id": "_:b273",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3223,38 +3277,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test055-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b412",
+              "@id": "_:b466",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055m",
               "result": {
-                "@id": "_:b413",
+                "@id": "_:b467",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b410",
+              "@id": "_:b109",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b411",
+                "@id": "_:b110",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b110",
+              "@id": "_:b274",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b111",
+                "@id": "_:b275",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3277,39 +3332,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test056-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b252",
+              "@id": "_:b416",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b253",
+                "@id": "_:b417",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b414",
+              "@id": "_:b111",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b415",
+                "@id": "_:b112",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b112",
+              "@id": "_:b276",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b113",
+                "@id": "_:b277",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3332,38 +3388,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test056-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b418",
+              "@id": "_:b468",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056m",
               "result": {
-                "@id": "_:b419",
+                "@id": "_:b469",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b416",
+              "@id": "_:b113",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b417",
+                "@id": "_:b114",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b114",
+              "@id": "_:b278",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b115",
+                "@id": "_:b279",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3386,39 +3443,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test057-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b254",
+              "@id": "_:b418",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b255",
+                "@id": "_:b419",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b420",
+              "@id": "_:b115",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b421",
+                "@id": "_:b116",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b116",
+              "@id": "_:b280",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b117",
+                "@id": "_:b281",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3441,38 +3499,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test057-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b424",
+              "@id": "_:b470",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057m",
               "result": {
-                "@id": "_:b425",
+                "@id": "_:b471",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b422",
+              "@id": "_:b117",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b423",
+                "@id": "_:b118",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b118",
+              "@id": "_:b282",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b119",
+                "@id": "_:b283",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3495,39 +3554,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test058-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b256",
+              "@id": "_:b420",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test058c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b257",
+                "@id": "_:b421",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b426",
+              "@id": "_:b119",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test058c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b427",
+                "@id": "_:b120",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b120",
+              "@id": "_:b284",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test058c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b121",
+                "@id": "_:b285",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3550,39 +3610,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test059-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b258",
+              "@id": "_:b422",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test059c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b259",
+                "@id": "_:b423",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b428",
+              "@id": "_:b121",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test059c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b429",
+                "@id": "_:b122",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b122",
+              "@id": "_:b286",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test059c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b123",
+                "@id": "_:b287",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3605,39 +3666,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test060-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b260",
+              "@id": "_:b424",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b261",
+                "@id": "_:b425",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b430",
+              "@id": "_:b123",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b431",
+                "@id": "_:b124",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b124",
+              "@id": "_:b288",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b125",
+                "@id": "_:b289",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3660,38 +3722,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test060-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b434",
+              "@id": "_:b472",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060m",
               "result": {
-                "@id": "_:b435",
+                "@id": "_:b473",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b432",
+              "@id": "_:b125",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b433",
+                "@id": "_:b126",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b126",
+              "@id": "_:b290",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b127",
+                "@id": "_:b291",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3714,39 +3777,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test061-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b262",
+              "@id": "_:b426",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test061c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b263",
+                "@id": "_:b427",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b436",
+              "@id": "_:b127",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test061c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b437",
+                "@id": "_:b128",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b128",
+              "@id": "_:b292",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test061c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b129",
+                "@id": "_:b293",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3769,39 +3833,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test062-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b264",
+              "@id": "_:b428",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test062c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b265",
+                "@id": "_:b429",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b438",
+              "@id": "_:b129",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test062c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b439",
+                "@id": "_:b130",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b130",
+              "@id": "_:b294",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test062c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b131",
+                "@id": "_:b295",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3825,39 +3890,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test063-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b266",
+              "@id": "_:b430",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b267",
+                "@id": "_:b431",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b440",
+              "@id": "_:b131",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b441",
+                "@id": "_:b132",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b132",
+              "@id": "_:b296",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b133",
+                "@id": "_:b297",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3881,38 +3947,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test063-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b444",
+              "@id": "_:b474",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063m",
               "result": {
-                "@id": "_:b445",
+                "@id": "_:b475",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b442",
+              "@id": "_:b133",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b443",
+                "@id": "_:b134",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b134",
+              "@id": "_:b298",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b135",
+                "@id": "_:b299",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3935,39 +4002,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test064-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b268",
+              "@id": "_:b432",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test064c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b269",
+                "@id": "_:b433",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b446",
+              "@id": "_:b135",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test064c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b447",
+                "@id": "_:b136",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b136",
+              "@id": "_:b300",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test064c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b137",
+                "@id": "_:b301",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3990,39 +4058,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test065-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b270",
+              "@id": "_:b434",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test065c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b271",
+                "@id": "_:b435",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b448",
+              "@id": "_:b137",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test065c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b449",
+                "@id": "_:b138",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b138",
+              "@id": "_:b302",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test065c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b139",
+                "@id": "_:b303",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4045,39 +4114,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test066-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b272",
+              "@id": "_:b436",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test066c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b273",
+                "@id": "_:b437",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b450",
+              "@id": "_:b139",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test066c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b451",
+                "@id": "_:b140",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b140",
+              "@id": "_:b304",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test066c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b141",
+                "@id": "_:b305",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4100,39 +4170,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test067-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b274",
+              "@id": "_:b438",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test067c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b275",
+                "@id": "_:b439",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b452",
+              "@id": "_:b141",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test067c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b453",
+                "@id": "_:b142",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b142",
+              "@id": "_:b306",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test067c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b143",
+                "@id": "_:b307",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4155,39 +4226,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test068-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b276",
+              "@id": "_:b440",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test068c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b277",
+                "@id": "_:b441",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b454",
+              "@id": "_:b143",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test068c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b455",
+                "@id": "_:b144",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b144",
+              "@id": "_:b308",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test068c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b145",
+                "@id": "_:b309",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4210,39 +4282,40 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test069-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b278",
+              "@id": "_:b442",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test069c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b279",
+                "@id": "_:b443",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b456",
+              "@id": "_:b145",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test069c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b457",
+                "@id": "_:b146",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b146",
+              "@id": "_:b310",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test069c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b147",
+                "@id": "_:b311",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4266,38 +4339,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test070-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b460",
+              "@id": "_:b476",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test070c",
               "result": {
-                "@id": "_:b461",
+                "@id": "_:b477",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b458",
+              "@id": "_:b147",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test070c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b459",
+                "@id": "_:b148",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b148",
+              "@id": "_:b312",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test070c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b149",
+                "@id": "_:b313",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4321,38 +4395,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test070-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b464",
+              "@id": "_:b478",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test070m",
               "result": {
-                "@id": "_:b465",
+                "@id": "_:b479",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b462",
+              "@id": "_:b149",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test070m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b463",
+                "@id": "_:b150",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b150",
+              "@id": "_:b314",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test070m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b151",
+                "@id": "_:b315",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4376,38 +4451,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test071-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b468",
+              "@id": "_:b480",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test071c",
               "result": {
-                "@id": "_:b469",
+                "@id": "_:b481",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b466",
+              "@id": "_:b151",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test071c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b467",
+                "@id": "_:b152",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b152",
+              "@id": "_:b316",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test071c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b153",
+                "@id": "_:b317",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4431,38 +4507,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test071-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b472",
+              "@id": "_:b482",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test071m",
               "result": {
-                "@id": "_:b473",
+                "@id": "_:b483",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b470",
+              "@id": "_:b153",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test071m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b471",
+                "@id": "_:b154",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b154",
+              "@id": "_:b318",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test071m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b155",
+                "@id": "_:b319",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4486,38 +4563,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test072-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b476",
+              "@id": "_:b484",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test072c",
               "result": {
-                "@id": "_:b477",
+                "@id": "_:b485",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b474",
+              "@id": "_:b155",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test072c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b475",
+                "@id": "_:b156",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b156",
+              "@id": "_:b320",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test072c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b157",
+                "@id": "_:b321",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4541,38 +4619,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test072-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b480",
+              "@id": "_:b486",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test072m",
               "result": {
-                "@id": "_:b481",
+                "@id": "_:b487",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b478",
+              "@id": "_:b157",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test072m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b479",
+                "@id": "_:b158",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b158",
+              "@id": "_:b322",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test072m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b159",
+                "@id": "_:b323",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4596,38 +4675,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test073-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b484",
+              "@id": "_:b488",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test073c",
               "result": {
-                "@id": "_:b485",
+                "@id": "_:b489",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b482",
+              "@id": "_:b159",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test073c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b483",
+                "@id": "_:b160",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b160",
+              "@id": "_:b324",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test073c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b161",
+                "@id": "_:b325",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4651,38 +4731,39 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test073-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b488",
+              "@id": "_:b490",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test073m",
               "result": {
-                "@id": "_:b489",
+                "@id": "_:b491",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b486",
+              "@id": "_:b161",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test073m",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b487",
+                "@id": "_:b162",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b162",
+              "@id": "_:b326",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test073m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b163",
+                "@id": "_:b327",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4717,26 +4798,27 @@
               "assertedBy": null
             },
             {
-              "@id": "_:b490",
+              "@id": "_:b163",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test074c",
+              "assertedBy": "https://www.ivan-herman.net/foaf#me",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b491",
+                "@id": "_:b164",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b164",
+              "@id": "_:b328",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test074c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b165",
+                "@id": "_:b329",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }

--- a/reports/earl.ttl
+++ b/reports/earl.ttl
@@ -127,9 +127,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test001c> ;
@@ -162,9 +161,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test002c> ;
@@ -197,9 +195,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test003c> ;
@@ -265,9 +262,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test004c> ;
@@ -333,9 +329,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test005c> ;
@@ -401,9 +396,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test006c> ;
@@ -436,9 +430,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test008c> ;
@@ -471,9 +464,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test009c> ;
@@ -506,9 +498,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test010c> ;
@@ -541,9 +532,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test011c> ;
@@ -576,9 +566,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test013c> ;
@@ -611,9 +600,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test014c> ;
@@ -646,9 +634,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test016c> ;
@@ -714,9 +701,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test017c> ;
@@ -782,9 +768,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test018c> ;
@@ -850,9 +835,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test019c> ;
@@ -885,9 +869,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test020c> ;
@@ -953,9 +936,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test021c> ;
@@ -988,9 +970,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test022c> ;
@@ -1023,9 +1004,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test023c> ;
@@ -1058,9 +1038,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test024c> ;
@@ -1093,9 +1072,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test025c> ;
@@ -1128,9 +1106,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test026c> ;
@@ -1163,9 +1140,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test027c> ;
@@ -1198,9 +1174,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test028c> ;
@@ -1233,9 +1208,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test029c> ;
@@ -1268,9 +1242,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test030c> ;
@@ -1336,9 +1309,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test033c> ;
@@ -1371,9 +1343,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test034c> ;
@@ -1406,9 +1377,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test035c> ;
@@ -1441,9 +1411,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test036c> ;
@@ -1476,9 +1445,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test038c> ;
@@ -1511,9 +1479,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test039c> ;
@@ -1546,9 +1513,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test040c> ;
@@ -1581,9 +1547,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test043c> ;
@@ -1617,9 +1582,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test044c> ;
@@ -1653,9 +1617,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test045c> ;
@@ -1689,9 +1652,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test046c> ;
@@ -1724,9 +1686,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test047c> ;
@@ -1792,9 +1753,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test048c> ;
@@ -1860,9 +1820,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test053c> ;
@@ -1928,9 +1887,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test054c> ;
@@ -1963,9 +1921,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test055c> ;
@@ -2031,9 +1988,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test056c> ;
@@ -2099,9 +2055,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test057c> ;
@@ -2167,9 +2122,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test058c> ;
@@ -2202,9 +2156,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test059c> ;
@@ -2237,9 +2190,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test060c> ;
@@ -2305,9 +2257,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test061c> ;
@@ -2340,9 +2291,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test062c> ;
@@ -2376,9 +2326,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test063c> ;
@@ -2445,9 +2394,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test064c> ;
@@ -2480,9 +2428,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test065c> ;
@@ -2515,9 +2462,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test066c> ;
@@ -2550,9 +2496,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test067c> ;
@@ -2585,9 +2530,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test068c> ;
@@ -2620,9 +2564,8 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:passed
+      earl:outcome earl:untested
     ] ;
-    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test069c> ;
@@ -2956,7 +2899,7 @@
   doap:homepage <https://iherman.github.io/rdfjs-c14n/> ;
   doap:description "Implementation in Typescript of the RDF Canonicalization Algorithm RDFC-1.0, on top of the RDF/JS interfaces"@en ;
   doap:programming-language "TypeScript" ;
-  doap:release [doap:revision "2.0.0"] .
+  doap:release [doap:revision "2.0.2"] .
 
 <https://www.ivan-herman.net/foaf#me> a foaf:Person, earl:Assertor ;
   foaf:name "Ivan Herman" ;
@@ -2988,5 +2931,5 @@
 
 <https://github.com/gkellogg/earl-report/tree/0.8.0> a doap:Version;
   doap:name "earl-report-0.8.0";
-  doap:created "2023-07-04"^^xsd:date;
+  doap:created "2023-07-05"^^xsd:date;
   doap:revision "0.8.0" .

--- a/reports/earl.ttl
+++ b/reports/earl.ttl
@@ -127,8 +127,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test001c> ;
@@ -161,8 +162,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test002c> ;
@@ -195,8 +197,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test003c> ;
@@ -228,8 +231,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test003m> ;
@@ -262,8 +266,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test004c> ;
@@ -295,8 +300,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test004m> ;
@@ -329,8 +335,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test005c> ;
@@ -362,8 +369,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test005m> ;
@@ -396,8 +404,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test006c> ;
@@ -430,8 +439,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test008c> ;
@@ -464,8 +474,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test009c> ;
@@ -498,8 +509,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test010c> ;
@@ -532,8 +544,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test011c> ;
@@ -566,8 +579,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test013c> ;
@@ -600,8 +614,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test014c> ;
@@ -634,8 +649,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test016c> ;
@@ -667,8 +683,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test016m> ;
@@ -701,8 +718,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test017c> ;
@@ -734,8 +752,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test017m> ;
@@ -768,8 +787,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test018c> ;
@@ -801,8 +821,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test018m> ;
@@ -835,8 +856,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test019c> ;
@@ -869,8 +891,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test020c> ;
@@ -902,8 +925,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test020m> ;
@@ -936,8 +960,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test021c> ;
@@ -970,8 +995,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test022c> ;
@@ -1004,8 +1030,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test023c> ;
@@ -1038,8 +1065,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test024c> ;
@@ -1072,8 +1100,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test025c> ;
@@ -1106,8 +1135,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test026c> ;
@@ -1140,8 +1170,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test027c> ;
@@ -1174,8 +1205,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test028c> ;
@@ -1208,8 +1240,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test029c> ;
@@ -1242,8 +1275,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test030c> ;
@@ -1275,8 +1309,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test030m> ;
@@ -1309,8 +1344,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test033c> ;
@@ -1343,8 +1379,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test034c> ;
@@ -1377,8 +1414,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test035c> ;
@@ -1411,8 +1449,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test036c> ;
@@ -1445,8 +1484,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test038c> ;
@@ -1479,8 +1519,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test039c> ;
@@ -1513,8 +1554,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test040c> ;
@@ -1547,8 +1589,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test043c> ;
@@ -1582,8 +1625,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test044c> ;
@@ -1617,8 +1661,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test045c> ;
@@ -1652,8 +1697,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test046c> ;
@@ -1686,8 +1732,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test047c> ;
@@ -1719,8 +1766,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test047m> ;
@@ -1753,8 +1801,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test048c> ;
@@ -1786,8 +1835,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test048m> ;
@@ -1820,8 +1870,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test053c> ;
@@ -1853,8 +1904,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test053m> ;
@@ -1887,8 +1939,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test054c> ;
@@ -1921,8 +1974,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test055c> ;
@@ -1954,8 +2008,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test055m> ;
@@ -1988,8 +2043,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test056c> ;
@@ -2021,8 +2077,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test056m> ;
@@ -2055,8 +2112,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test057c> ;
@@ -2088,8 +2146,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test057m> ;
@@ -2122,8 +2181,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test058c> ;
@@ -2156,8 +2216,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test059c> ;
@@ -2190,8 +2251,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test060c> ;
@@ -2223,8 +2285,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test060m> ;
@@ -2257,8 +2320,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test061c> ;
@@ -2291,8 +2355,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test062c> ;
@@ -2326,8 +2391,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test063c> ;
@@ -2360,8 +2426,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test063m> ;
@@ -2394,8 +2461,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test064c> ;
@@ -2428,8 +2496,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test065c> ;
@@ -2462,8 +2531,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test066c> ;
@@ -2496,8 +2566,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test067c> ;
@@ -2530,8 +2601,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test068c> ;
@@ -2564,8 +2636,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test069c> ;
@@ -2598,8 +2671,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test070c> ;
@@ -2632,8 +2706,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test070m> ;
@@ -2666,8 +2741,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test071c> ;
@@ -2700,8 +2776,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test071m> ;
@@ -2734,8 +2811,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test072c> ;
@@ -2768,8 +2846,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test072m> ;
@@ -2802,8 +2881,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test073c> ;
@@ -2836,8 +2916,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test073m> ;
@@ -2869,8 +2950,9 @@
     earl:subject <https://iherman.github.io/rdfjs-c14n/> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test074c> ;
@@ -2931,5 +3013,5 @@
 
 <https://github.com/gkellogg/earl-report/tree/0.8.0> a doap:Version;
   doap:name "earl-report-0.8.0";
-  doap:created "2023-07-05"^^xsd:date;
+  doap:created "2023-07-10"^^xsd:date;
   doap:revision "0.8.0" .

--- a/reports/index.html
+++ b/reports/index.html
@@ -92,8 +92,8 @@ RDF Dataset Canonicalization and Hash 1.0 Processor Conformance
 EARL results from the RDF Dataset Canonicalization and Hash 1.0 Test Suite
 </h2>
 <h2 id='w3c-document-28-october-2015'>
-<time class='dt-published' datetime='2023-07-05' property='dc:issued'>
-05 July 2023
+<time class='dt-published' datetime='2023-07-10' property='dc:issued'>
+10 July 2023
 </time>
 </h2>
 <dl>
@@ -309,6 +309,13 @@ Sophia
 </a>
 </th>
 <th>
+<a href='#subj_rdfjs_c14n_TypeScript'>
+rdfjs-c14n
+<br />
+(TypeScript)
+</a>
+</th>
+<th>
 <a href='#subj_Ruby_RDF_Normalize_Ruby'>
 Ruby RDF::Normalize
 <br />
@@ -319,6 +326,9 @@ Ruby RDF::Normalize
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test001c'>Test test001c: simple id</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -337,10 +347,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test003c'>Test test003c: bnode</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -359,10 +375,16 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test004c'>Test test004c: bnode plus embed w/subject</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -381,10 +403,16 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test005c'>Test test005c: bnode embed</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -403,10 +431,16 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test006c'>Test test006c: multiple rdf types</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -425,10 +459,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test009c'>Test test009c: multiple subjects - complex</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -447,10 +487,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test011c'>Test test011c: type-coerced type</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -469,10 +515,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test014c'>Test test014c: check types</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -491,6 +543,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -502,10 +557,16 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test017c'>Test test017c: blank node - dual link - non-embed</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -524,10 +585,16 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test018c'>Test test018c: blank node - self link</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -546,10 +613,16 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test019c'>Test test019c: blank node - disjoint self links</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -568,6 +641,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -579,10 +655,16 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test021c'>Test test021c: blank node - circle of 2</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -601,10 +683,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test023c'>Test test023c: blank node - circle of 3</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -623,10 +711,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test025c'>Test test025c: blank node - double circle of 3 (0-2-1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -645,10 +739,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test027c'>Test test027c: blank node - double circle of 3 (1-2-0)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -667,10 +767,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test029c'>Test test029c: blank node - double circle of 3 (2-0-1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -689,6 +795,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -700,10 +809,16 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test033c'>Test test033c: disjoint identical subgraphs (1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -722,10 +837,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test035c'>Test test035c: reordered w/strings (1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -744,10 +865,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test038c'>Test test038c: reordered 4 bnodes, reordered 2 properties (1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -766,10 +893,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test040c'>Test test040c: reordered 6 bnodes (1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -788,10 +921,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test044c'>Test test044c: poison – evil (1)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -810,10 +949,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test046c'>Test test046c: poison – evil (3)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -832,6 +977,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -843,10 +991,16 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test048c'>Test test048c: deep diff (2)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -865,10 +1019,16 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test053c'>Test test053c: @list</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -887,10 +1047,16 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test054c'>Test test054c: t-graph</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -909,6 +1075,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -920,10 +1089,16 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test056c'>Test test056c: simple reorder (2)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -942,10 +1117,16 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test057c'>Test test057c: unnamed graph</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -964,10 +1145,16 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test058c'>Test test058c: unnamed graph with blank node objects</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -986,10 +1173,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test060c'>Test test060c: n-quads escaping</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1008,10 +1201,16 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test061c'>Test test061c: same literal value with multiple languages</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1030,10 +1229,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test063c'>Test test063c: blank node - diamond (with _:b)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1052,10 +1257,16 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test064c'>Test test064c: blank node - double circle of 3 (0-1-2, reversed)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1074,10 +1285,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test066c'>Test test066c: blank node - double circle of 3 (1-0-2, reversed)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1096,10 +1313,16 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test068c'>Test test068c: blank node - double circle of 3 (2-1-0, reversed)</a>
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1118,6 +1341,9 @@ PASS
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -1125,6 +1351,9 @@ PASS
 </td>
 <td class='UNTESTED'>
 UNTESTED
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1140,6 +1369,9 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -1147,6 +1379,9 @@ PASS
 </td>
 <td class='UNTESTED'>
 UNTESTED
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1162,6 +1397,9 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -1169,6 +1407,9 @@ PASS
 </td>
 <td class='UNTESTED'>
 UNTESTED
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1184,6 +1425,9 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -1191,6 +1435,9 @@ PASS
 </td>
 <td class='UNTESTED'>
 UNTESTED
+</td>
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1206,6 +1453,9 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -1217,6 +1467,9 @@ UNTESTED
 <td class='PASS'>
 PASS
 </td>
+<td class='PASS'>
+PASS
+</td>
 </tr>
 <tr class='summary'>
 <td>
@@ -1224,6 +1477,9 @@ Percentage passed out of 82 Tests
 </td>
 <td class='passed-some'>
 69.5%
+</td>
+<td class='passed-all'>
+100.0%
 </td>
 <td class='passed-all'>
 100.0%
@@ -1325,6 +1581,14 @@ Test Suite Compliance
 <dd>
 <table class='report'>
 <tbody>
+<tr>
+<td>
+
+</td>
+<td class='passed-all'>
+82/82 (100.0%)
+</td>
+</tr>
 </tbody>
 </table>
 </dd>

--- a/reports/index.html
+++ b/reports/index.html
@@ -92,8 +92,8 @@ RDF Dataset Canonicalization and Hash 1.0 Processor Conformance
 EARL results from the RDF Dataset Canonicalization and Hash 1.0 Test Suite
 </h2>
 <h2 id='w3c-document-28-october-2015'>
-<time class='dt-published' datetime='2023-07-04' property='dc:issued'>
-04 July 2023
+<time class='dt-published' datetime='2023-07-05' property='dc:issued'>
+05 July 2023
 </time>
 </h2>
 <dl>
@@ -309,13 +309,6 @@ Sophia
 </a>
 </th>
 <th>
-<a href='#subj_rdfjs_c14n_TypeScript'>
-rdfjs-c14n
-<br />
-(TypeScript)
-</a>
-</th>
-<th>
 <a href='#subj_Ruby_RDF_Normalize_Ruby'>
 Ruby RDF::Normalize
 <br />
@@ -326,9 +319,6 @@ Ruby RDF::Normalize
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test001c'>Test test001c: simple id</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -347,9 +337,6 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -361,16 +348,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test003m'>Test test003m: bnode (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -389,16 +370,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test004m'>Test test004m: bnode plus embed w/subject (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -417,16 +392,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test005m'>Test test005m: bnode embed (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -445,16 +414,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test008c'>Test test008c: single subject complex</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -473,16 +436,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test010c'>Test test010c: type</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -501,16 +458,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test013c'>Test test013c: type-coerced type, cycle</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -529,9 +480,6 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -543,16 +491,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test016m'>Test test016m: blank node - dual link - embed (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -571,16 +513,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test017m'>Test test017m: blank node - dual link - non-embed (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -599,16 +535,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test018m'>Test test018m: blank node - self link (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -627,9 +557,6 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -641,16 +568,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test020m'>Test test020m: blank node - diamond (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -669,16 +590,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test022c'>Test test022c: blank node - double circle of 2</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -697,16 +612,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test024c'>Test test024c: blank node - double circle of 3 (0-1-2)</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -725,16 +634,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test026c'>Test test026c: blank node - double circle of 3 (1-0-2)</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -753,16 +656,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test028c'>Test test028c: blank node - double circle of 3 (2-1-0)</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -781,9 +678,6 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -795,16 +689,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test030m'>Test test030m: blank node - point at circle of 3 (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -823,16 +711,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test034c'>Test test034c: disjoint identical subgraphs (2)</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -851,16 +733,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test036c'>Test test036c: reordered w/strings (2)</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -879,16 +755,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test039c'>Test test039c: reordered 4 bnodes, reordered 2 properties (2)</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -907,16 +777,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test043c'>Test test043c: literal with language</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -935,16 +799,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test045c'>Test test045c: poison – evil (2)</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -963,9 +821,6 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -977,16 +832,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test047m'>Test test047m: deep diff (1) (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -1005,16 +854,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test048m'>Test test048m: deep diff (2) (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -1033,16 +876,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test053m'>Test test053m: @list (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -1061,9 +898,6 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
@@ -1075,16 +909,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test055m'>Test test055m: simple reorder (1) (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -1103,16 +931,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test056m'>Test test056m: simple reorder (2) (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -1131,16 +953,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test057m'>Test test057m: unnamed graph (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -1159,16 +975,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test059c'>Test test059c: n-quads parsing</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1187,16 +997,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test060m'>Test test060m: n-quads escaping (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -1215,16 +1019,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test062c'>Test test062c: same literal value with multiple datatypes</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1243,16 +1041,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test063m'>Test test063m: blank node - diamond (with _:b) (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -1271,16 +1063,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test065c'>Test test065c: blank node - double circle of 3 (0-2-1, reversed)</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1299,16 +1085,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test067c'>Test test067c: blank node - double circle of 3 (1-2-0, reversed)</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1327,16 +1107,10 @@ PASS
 <td class='PASS'>
 PASS
 </td>
-<td class='PASS'>
-PASS
-</td>
 </tr>
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test069c'>Test test069c: blank node - double circle of 3 (2-0-1, reversed)</a>
-</td>
-<td class='PASS'>
-PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1352,9 +1126,6 @@ PASS
 <td class='UNTESTED'>
 UNTESTED
 </td>
-<td class='UNTESTED'>
-UNTESTED
-</td>
 <td class='PASS'>
 PASS
 </td>
@@ -1362,9 +1133,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test070m'>Test test070m: dataset - isomorphic default and iri named (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -1380,9 +1148,6 @@ PASS
 <td class='UNTESTED'>
 UNTESTED
 </td>
-<td class='UNTESTED'>
-UNTESTED
-</td>
 <td class='PASS'>
 PASS
 </td>
@@ -1390,9 +1155,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test071m'>Test test071m: dataset - isomorphic default and node named (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -1408,9 +1170,6 @@ PASS
 <td class='UNTESTED'>
 UNTESTED
 </td>
-<td class='UNTESTED'>
-UNTESTED
-</td>
 <td class='PASS'>
 PASS
 </td>
@@ -1418,9 +1177,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test072m'>Test test072m: dataset - shared blank nodes (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -1436,9 +1192,6 @@ PASS
 <td class='UNTESTED'>
 UNTESTED
 </td>
-<td class='UNTESTED'>
-UNTESTED
-</td>
 <td class='PASS'>
 PASS
 </td>
@@ -1446,9 +1199,6 @@ PASS
 <tr class='normative'>
 <td>
 <a href='https://w3c.github.io/rdf-canon/tests/manifest#test073m'>Test test073m: dataset - referencing graph name (map test)</a>
-</td>
-<td class='UNTESTED'>
-UNTESTED
 </td>
 <td class='UNTESTED'>
 UNTESTED
@@ -1464,9 +1214,6 @@ PASS
 <td class='UNTESTED'>
 UNTESTED
 </td>
-<td class='UNTESTED'>
-UNTESTED
-</td>
 <td class='PASS'>
 PASS
 </td>
@@ -1474,9 +1221,6 @@ PASS
 <tr class='summary'>
 <td>
 Percentage passed out of 82 Tests
-</td>
-<td class='passed-some'>
-69.5%
 </td>
 <td class='passed-some'>
 69.5%
@@ -1555,7 +1299,7 @@ Test Suite Compliance
 <dt>Description</dt>
 <dd lang='en' property='doap:description'>Implementation in Typescript of the RDF Canonicalization Algorithm RDFC-1.0, on top of the RDF/JS interfaces</dd>
 <dt>Release</dt>
-<dd property='doap:release'><span property='doap:revision'>2.0.0</span></dd>
+<dd property='doap:release'><span property='doap:revision'>2.0.2</span></dd>
 <dt>Programming Language</dt>
 <dd property='doap:programming-language'>TypeScript</dd>
 <dt>Home Page</dt>
@@ -1581,14 +1325,6 @@ Test Suite Compliance
 <dd>
 <table class='report'>
 <tbody>
-<tr>
-<td>
-
-</td>
-<td class='passed-some'>
-57/82 (69.5%)
-</td>
-</tr>
 </tbody>
 </table>
 </dd>

--- a/reports/rdfjs-c14n-report.ttl
+++ b/reports/rdfjs-c14n-report.ttl
@@ -7,7 +7,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 
 <> foaf:primaryTopic <https://iherman.github.io/rdfjs-c14n/> ;
-  dc:issued  "2023-06-14T11:46:45.444Z"^^xsd:dateTime ;
+  dc:issued  "2023-07-05T13:06:38.489Z"^^xsd:dateTime ;
   foaf:maker <https://www.ivan-herman.net/foaf#me> .
 
 <https://iherman.github.io/rdfjs-c14n/> a doap:Project ;
@@ -31,8 +31,8 @@
   doap:release [
     a doap:Version ;
     doap:name     "rdfjs-c14n";
-    doap:revision "2.0.0";
-    doap:created  "2013-06-14"^^xsd:date ;
+    doap:revision "2.0.2";
+    doap:created  "2013-07-05"^^xsd:date ;
   ] ;
   doap:repository [
     a doap:GitRepository ;
@@ -49,11 +49,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test001c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test001c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -62,11 +62,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test002c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test002c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -75,11 +75,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test003c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test003c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -88,11 +88,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test004c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test003m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -101,11 +101,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test005c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test004c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -114,11 +114,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test006c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test004m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -127,11 +127,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test008c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test005c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -140,11 +140,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test009c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test005m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -153,11 +153,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test010c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test006c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -166,11 +166,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test011c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test008c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -179,11 +179,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test013c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test009c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -192,11 +192,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test014c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test010c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -205,11 +205,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test016c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test011c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -218,11 +218,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test017c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test013c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -231,11 +231,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test018c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test014c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -244,11 +244,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test019c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test016c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -257,11 +257,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test020c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test016m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -270,11 +270,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test021c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test017c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -283,11 +283,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test022c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test017m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -296,11 +296,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test023c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test018c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -309,11 +309,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test024c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test018m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -322,11 +322,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test025c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test019c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -335,11 +335,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test026c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test020c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -348,11 +348,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test027c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test020m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -361,11 +361,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test028c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test021c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -374,11 +374,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test029c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test022c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -387,11 +387,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test030c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test023c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -400,11 +400,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test033c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test024c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -413,11 +413,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test034c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test025c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -426,11 +426,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test035c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test026c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -439,11 +439,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test036c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test027c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -452,11 +452,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test038c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test028c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -465,11 +465,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test039c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test029c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -478,11 +478,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test040c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test030c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -491,11 +491,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test043c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test030m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -504,11 +504,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test044c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test033c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -517,11 +517,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test045c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test034c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -530,11 +530,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test046c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test035c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -543,11 +543,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test047c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test036c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -556,11 +556,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test048c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test038c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -569,11 +569,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test053c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test039c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -582,11 +582,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test054c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test040c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -595,11 +595,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test055c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test043c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -608,11 +608,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test056c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test044c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -621,11 +621,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test057c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test045c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -634,11 +634,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test058c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test046c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -647,11 +647,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test059c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test047c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -660,11 +660,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test060c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test047m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -673,11 +673,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test061c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test048c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -686,11 +686,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test062c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test048m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -699,11 +699,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test063c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test053c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -712,11 +712,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test064c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test053m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -725,11 +725,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test065c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test054c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -738,11 +738,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test066c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test055c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -751,11 +751,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test067c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test055m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -764,11 +764,11 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test068c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test056c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -777,11 +777,336 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test069c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test056m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-06-14T11:46:45.444Z"^^xsd:dateTime
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test057c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test057m> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test058c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test059c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test060c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test060m> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test061c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test062c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test063c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test063m> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test064c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test065c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test066c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test067c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test068c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test069c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test070c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test070m> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test071c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test071m> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test072c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test072m> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test073c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test073m> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
+    ];
+    earl:mode earl:automatic
+] .
+
+[ 
+    a earl:Assertion ;
+    earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
+    earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/#test074c> ;
+    earl:result [
+        a earl:TestResult ;
+        earl:outcome earl:passed ;
+        dc:date      "2023-07-05T13:06:38.489Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .

--- a/reports/rdfjs-c14n-report.ttl
+++ b/reports/rdfjs-c14n-report.ttl
@@ -49,7 +49,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test001c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test001c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -62,7 +62,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test002c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test002c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -75,7 +75,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test003c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test003c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -88,7 +88,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test003m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test003m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -101,7 +101,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test004c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test004c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -114,7 +114,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test004m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test004m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -127,7 +127,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test005c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test005c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -140,7 +140,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test005m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test005m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -153,7 +153,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test006c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test006c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -166,7 +166,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test008c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test008c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -179,7 +179,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test009c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test009c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -192,7 +192,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test010c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test010c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -205,7 +205,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test011c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test011c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -218,7 +218,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test013c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test013c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -231,7 +231,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test014c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test014c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -244,7 +244,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test016c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test016c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -257,7 +257,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test016m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test016m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -270,7 +270,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test017c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test017c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -283,7 +283,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test017m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test017m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -296,7 +296,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test018c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test018c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -309,7 +309,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test018m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test018m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -322,7 +322,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test019c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test019c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -335,7 +335,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test020c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test020c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -348,7 +348,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test020m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test020m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -361,7 +361,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test021c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test021c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -374,7 +374,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test022c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test022c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -387,7 +387,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test023c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test023c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -400,7 +400,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test024c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test024c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -413,7 +413,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test025c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test025c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -426,7 +426,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test026c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test026c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -439,7 +439,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test027c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test027c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -452,7 +452,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test028c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test028c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -465,7 +465,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test029c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test029c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -478,7 +478,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test030c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test030c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -491,7 +491,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test030m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test030m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -504,7 +504,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test033c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test033c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -517,7 +517,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test034c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test034c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -530,7 +530,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test035c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test035c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -543,7 +543,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test036c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test036c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -556,7 +556,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test038c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test038c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -569,7 +569,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test039c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test039c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -582,7 +582,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test040c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test040c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -595,7 +595,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test043c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test043c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -608,7 +608,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test044c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test044c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -621,7 +621,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test045c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test045c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -634,7 +634,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test046c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test046c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -647,7 +647,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test047c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test047c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -660,7 +660,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test047m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test047m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -673,7 +673,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test048c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test048c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -686,7 +686,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test048m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test048m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -699,7 +699,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test053c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test053c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -712,7 +712,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test053m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test053m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -725,7 +725,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test054c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test054c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -738,7 +738,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test055c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test055c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -751,7 +751,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test055m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test055m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -764,7 +764,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test056c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test056c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -777,7 +777,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test056m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test056m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -790,7 +790,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test057c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test057c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -803,7 +803,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test057m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test057m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -816,7 +816,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test058c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test058c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -829,7 +829,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test059c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test059c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -842,7 +842,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test060c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test060c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -855,7 +855,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test060m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test060m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -868,7 +868,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test061c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test061c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -881,7 +881,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test062c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test062c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -894,7 +894,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test063c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test063c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -907,7 +907,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test063m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test063m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -920,7 +920,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test064c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test064c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -933,7 +933,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test065c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test065c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -946,7 +946,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test066c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test066c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -959,7 +959,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test067c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test067c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -972,7 +972,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test068c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test068c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -985,7 +985,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test069c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test069c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -998,7 +998,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test070c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test070c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -1011,7 +1011,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test070m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test070m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -1024,7 +1024,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test071c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test071c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -1037,7 +1037,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test071m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test071m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -1050,7 +1050,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test072c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test072c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -1063,7 +1063,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test072m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test072m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -1076,7 +1076,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test073c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test073c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -1089,7 +1089,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test073m> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test073m> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
@@ -1102,7 +1102,7 @@
     a earl:Assertion ;
     earl:assertedBy <https://www.ivan-herman.net/foaf#me> ;
     earl:subject    <https://iherman.github.io/rdfjs-c14n/> ;
-    earl:test       <https://w3c.github.io/rdf-canon/tests/#test074c> ;
+    earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test074c> ;
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;


### PR DESCRIPTION
This update covers the latest test suite, including the poison graph