### PR TITLE
add note on permutations in the section on poisoning

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -2824,7 +2824,8 @@ disclose.
       <li>providing a configurable timeout with a default value applicable to
         an implementation's common use</li>
       <li>providing a configurable limit on the number of iterations of steps
-        performed in the algorithm, particularly recursive steps</li>
+        performed in the algorithm, particularly recursive steps
+        and permutations of long lists.</li>
     </ul>
 
     <p>Additionally, software that uses implementations of the algorithm can

--- a/spec/index.html
+++ b/spec/index.html
@@ -2825,7 +2825,7 @@ disclose.
         an implementation's common use</li>
       <li>providing a configurable limit on the number of iterations of steps
         performed in the algorithm, particularly recursive steps
-        and permutations of long lists.</li>
+        and permutations of long lists</li>
     </ul>
 
     <p>Additionally, software that uses implementations of the algorithm can


### PR DESCRIPTION
When implementing the algorithm, I was focusing on [recursion depth](https://www.w3.org/TR/rdf-canon/#hndq.5.4.5.1) in Hash N Degree Quads, and it took me some time to realize that it was in fact [step 5.4](https://www.w3.org/TR/rdf-canon/#hndq.5.4) that was the critical point in the poison graphs of the test suite.

This PR aims to save this time for future implementers :wink:


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/153.html" title="Last updated on Jul 27, 2023, 8:50 PM UTC (6465fae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/153/ed03ec4...6465fae.html" title="Last updated on Jul 27, 2023, 8:50 PM UTC (6465fae)">Diff</a>