### PR TITLE
Turn off hljs on logging pre sections.

### DIFF
--- a/spec/common/typographical-conventions.html
+++ b/spec/common/typographical-conventions.html
@@ -48,7 +48,7 @@
       <summary>Logging</summary>
       <p>For example, the following output snippet might
         describe the operation of an implementation using the [[?YAML]] format.</p>
-      <pre class="logging yaml" data-transform="updateExample">
+      <pre class="logging yaml nohighlight" data-transform="updateExample">
         <!--
         ca:
           ca2:

--- a/spec/index.html
+++ b/spec/index.html
@@ -1051,7 +1051,7 @@
           <details>
             <summary>Logging</summary>
             <p>Log the state of the <a>blank node to quads map</a>:</p>
-            <pre class="logging yaml" data-transform="updateExample">
+            <pre class="logging yaml nohighlight" data-transform="updateExample">
               <!--
                 # Blank node to quads map for unique hashes example
                 ca:
@@ -1089,7 +1089,7 @@
           <details>
             <summary>Logging</summary>
             <p>Log the results from the <a href="#hash-1d-quads-algorithm">Hash First Degree Quads algorithm</a>.</p>
-            <pre class="logging yaml" data-transform="updateExample">
+            <pre class="logging yaml nohighlight" data-transform="updateExample">
               <!--
                 # First degree hashes for unique hashes example
                 ca:
@@ -1139,7 +1139,7 @@
           <details>
             <summary>Logging</summary>
             <p>Log the assigned canonical identifiers.</p>
-            <pre class="logging yaml" data-transform="updateExample">
+            <pre class="logging yaml nohighlight" data-transform="updateExample">
               <!--
                 # Assigned canonical identifiers for shared hashes example
                 ca:
@@ -1174,7 +1174,7 @@
           <details>
             <summary>Logging</summary>
             <p>Log <var>hash</var> and <var>identifier list</var> for this iteration.</p>
-            <pre class="logging yaml" data-transform="updateExample">
+            <pre class="logging yaml nohighlight" data-transform="updateExample">
               <!--
                 # Hash and Identifier List for each iteration of step 5 using shared hashes example
                 ca:
@@ -1223,7 +1223,7 @@
                   <details>
                     <summary>Logging</summary>
                     <p>Include logs for each call to <a href="#hash-nd-quads">Hash N-Degree Quads algorithm</a>.</p>
-                    <pre class="logging yaml" data-transform="updateExample">
+                    <pre class="logging yaml nohighlight" data-transform="updateExample">
                       <!--
                         # Logs from calls to Hash N-Degree Quads algorithm for shared hashes example
                         ca:
@@ -1289,7 +1289,7 @@
               <details>
                 <summary>Logging</summary>
                 <p>Log newly issued canonical identifiers.</p>
-                <pre class="logging yaml" data-transform="updateExample">
+                <pre class="logging yaml nohighlight" data-transform="updateExample">
                   <!--
                     # Newly issued canonical identifiers from step 5.3 for shared hashes example
                     ca:
@@ -1328,7 +1328,7 @@
           <details>
             <summary>Logging</summary>
             <p>Log the state of the <a>canonical issuer</a> at the completion of the algorithm.</p>
-            <pre class="logging yaml" data-transform="updateExample">
+            <pre class="logging yaml nohighlight" data-transform="updateExample">
               <!--
                 # Canonical issuer state after step 6 for shared hashes example
                 ca:
@@ -1678,7 +1678,7 @@
           <details>
             <summary>Logging</summary>
             <p>Log the inputs and result of running this algorithm.</p>
-            <pre class="logging yaml" data-transform="updateExample">
+            <pre class="logging yaml nohighlight" data-transform="updateExample">
               <!--
                 # Inputs and hash result for the Hash First Degree Hash algorithm for unique hashes example
                 h1dq:
@@ -1810,7 +1810,7 @@
           <details>
             <summary>Logging</summary>
             <p>Log the inputs and result of running this algorithm.</p>
-            <pre class="logging yaml" data-transform="updateExample">
+            <pre class="logging yaml nohighlight" data-transform="updateExample">
               <!--
                 # Inputs and hash result for the Hash Related Blank algorithm for shared hashes example
                 hndq3.1:
@@ -2285,7 +2285,7 @@
       <details>
         <summary>Logging</summary>
         <p>Log the inputs to the algorithm.</p>
-        <pre class="logging yaml" data-transform="updateExample">
+        <pre class="logging yaml nohighlight" data-transform="updateExample">
           <!--
             # Inputs for the Hash N-Degree Quads algorithm for double circle example
             hndq:
@@ -2311,7 +2311,7 @@
           <details>
             <summary>Logging</summary>
             <p>Log the quads from the <a>mention set</a> of <var>identifier</var>.</p>
-            <pre class="logging yaml" data-transform="updateExample">
+            <pre class="logging yaml nohighlight" data-transform="updateExample">
               <!--
                 # Inputs for the Hash N-Degree Quads algorithm for double circle example
                 hndq:
@@ -2364,7 +2364,7 @@
             <p>Include the logs for each iteration of the
               <a href="#hash-related-blank-node">Hash Related Blank Node algorithm</a>
               and the resulting <var>H<sub>n</sub></var>.</p>
-            <pre class="logging yaml" data-transform="updateExample">
+            <pre class="logging yaml nohighlight" data-transform="updateExample">
               <!--
                 # Step 3 of Hash N-Degree Quads using double circle example
                 hndq:
@@ -2432,7 +2432,7 @@
             <summary>Logging</summary>
             <p>Log the value of <var>related hash</var>
               and state of <var>data to hash</var>.</p>
-            <pre class="logging yaml" data-transform="updateExample">
+            <pre class="logging yaml nohighlight" data-transform="updateExample">
               <!--
                 # Log related hash and data to hash in each iteration of step 5 for double circle example.
                 hndq:
@@ -2457,7 +2457,7 @@
               <details>
                 <summary>Logging</summary>
                 <p>Log each <a href="https://en.wikipedia.org/wiki/Permutation">permutation</a> <var>p</var>.</p>
-                <pre class="logging yaml" data-transform="updateExample">
+                <pre class="logging yaml nohighlight" data-transform="updateExample">
                   <!--
                     # Log each permutation of step 5.4 using double circle example.
                     hndq:
@@ -2541,7 +2541,7 @@
                   <details>
                     <summary>Logging</summary>
                     <p>Log <var>related</var> and <var>path</var>.</p>
-                    <pre class="logging yaml" data-transform="updateExample">
+                    <pre class="logging yaml nohighlight" data-transform="updateExample">
                       <!--
                         # Log related and path of step 5.4.4 using double circle example.
                         hndq:
@@ -2578,7 +2578,7 @@
                   <details>
                     <summary>Logging</summary>
                     <p>Log <var>recursion list</var> and <var>path</var>.</p>
-                    <pre class="logging yaml" data-transform="updateExample">
+                    <pre class="logging yaml nohighlight" data-transform="updateExample">
                       <!--
                         # Log related and path of step 5.4.5 using double circle example.
                         hndq:
@@ -2614,7 +2614,7 @@
                         <summary>Logging</summary>
                         <p>Log <var>related</var> and
                           include logs for each recursive call to <a href="#hash-nd-quads">Hash N-Degree Quads algorithm</a>.</p>
-                        <pre class="logging yaml" data-transform="updateExample">
+                        <pre class="logging yaml nohighlight" data-transform="updateExample">
                           <!--
                           # Log related and path of step 5.4.5.1 using double circle example.
                           hndq:
@@ -2677,7 +2677,7 @@
               <details>
                 <summary>Logging</summary>
                 <p>Log <var>chosen path</var> and <var>data to hash</var>.</p>
-                <pre class="logging yaml" data-transform="updateExample">
+                <pre class="logging yaml nohighlight" data-transform="updateExample">
                   <!--
                     # Log chosen path and data to hash logs of step 5.5 using double circle example.
                     hndq:
@@ -2710,7 +2710,7 @@
             <summary>Logging</summary>
             <p>Log <var>issuer</var> and results from passing <var>data to hash</var>
               through the <a>hash algorithm</a>.</p>
-            <pre class="logging yaml" data-transform="updateExample">
+            <pre class="logging yaml nohighlight" data-transform="updateExample">
               <!--
                 # Log issuer and resulting hash of step 6 using double circle example.
                 hndq:

--- a/spec/index.html
+++ b/spec/index.html
@@ -113,7 +113,8 @@
   pre.logging	{
     border: thin solid #88AA88;
     background-color: #E8F0E8;
-    margin: 1em 4em 1em 0em ;
+    margin: 1em 4em 1em 0em;
+    padding: 0.3em;
   }
   table.log ul { padding: 0; margin: 0; }
   table.log td { text-align: left; vertical-align: top;}


### PR DESCRIPTION
In Chrome, this caused the exxpected log messages not to appear.

Fixes #147.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/154.html" title="Last updated on Jul 28, 2023, 6:21 PM UTC (b9d544c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/154/84315eb...b9d544c.html" title="Last updated on Jul 28, 2023, 6:21 PM UTC (b9d544c)">Diff</a>