### PR TITLE
Clarify N-Quads canonicalization of langString

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -3542,7 +3542,7 @@ disclose.
           <a data-cite="RDF11-CONCEPTS#dfn-language-tag">language tags</a>
           This represents a potential interoperability issue if language tags
           are not converted to lower case uniformly, as different implementations
-          may end up using different canonical representations of such language tags.
+          might end up using different canonical representations of such language tags.
         </div>
     </li>
     <li><code><a data-cite="N-QUADS#grammar-production-HEX">HEX</a></code> MUST use only uppercase letters (<code>[A-F]</code>).</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1063,14 +1063,6 @@
               <a>input dataset</a> with both their original identifiers,
               and associated canonical identifiers.</p>
           </details>
-          <div class="issue" data-number="155">
-            [[RDF11-CONCEPTS]] allows implementations to convert
-            <a data-cite="RDF11-CONCEPTS#dfn-language-tag">language tags</a> to lower case
-            leading to different canonical forms of <a data-cite="RDF11-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>.
-            A possible solution is to require that all triples including a
-            <a data-cite="RDF11-CONCEPTS#dfn-language-tagged-string">language-tagged string</a>
-            be represented using only a lower case <a data-cite="RDF11-CONCEPTS#dfn-language-tag">language tag</a>.
-            Alternatively, the algorithm could simply detect such language tags and warn about the potential
             interoperability issue.
           </div>
         </li>
@@ -3531,19 +3523,9 @@ disclose.
       and <code>graphLabel</code>,
       each of which MUST be a single space (<code>U+0020</code>).</li>
     <li><a data-cite="RDF11-CONCEPTS#dfn-literal">Literals</a> with the
-      datatypes <code>http://www.w3.org/2001/XMLSchema#string</code> and
-      <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#langString</code>
+      datatype <code>http://www.w3.org/2001/XMLSchema#string</code>
       MUST NOT use the datatype IRI part of the <a data-cite="N-QUADS#grammar-production-literal">literal</a>,
-      and are represented using only <a data-cite="N-QUADS#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>
-        and <a href="N-QUADS#grammar-production-LANGTAG">LANGTAG</a>,
-        as appropriate.
-        <div class="issue" data-number="155">
-          [[RDF11-CONCEPTS]] allows implementations to convert
-          <a data-cite="RDF11-CONCEPTS#dfn-language-tag">language tags</a>.
-          This represents a potential interoperability issue if language tags
-          are not converted to lower case uniformly, as different implementations
-          might end up using different canonical representations of such language tags.
-        </div>
+      and are represented using only <a data-cite="N-QUADS#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.
     </li>
     <li><code><a data-cite="N-QUADS#grammar-production-HEX">HEX</a></code> MUST use only uppercase letters (<code>[A-F]</code>).</li>
     <li>Within <a data-cite="N-QUADS#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,

--- a/spec/index.html
+++ b/spec/index.html
@@ -194,7 +194,7 @@
   <div class="note">
     <p>[[[RDF11-CONCEPTS]]] [[RDF11-CONCEPTS]] lacks clarity on the representation of
       <a data-cite="RDF11-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>,
-      where <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tags</a> of the form `xx-YY`
+      where <a data-cite="RDF11-CONCEPTS#dfn-language-tag">language tags</a> of the form `xx-YY`
       are treated as being case insensitive. Implementations might represent language tags
       using all lower case in the form `xx-yy`,
       retain the original representation `xx-YY`,
@@ -202,10 +202,10 @@
       leading to different canonical forms, and therefore, different hashed values.</p>
     <ul>
       <li>The Canonicalization algorithm is based on the RDF 1.1 definition,
-        in the sense that the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> `xx-YY`
+        in the sense that the <a data-cite="RDF11-CONCEPTS#dfn-language-tag">language tag</a> `xx-YY`
         is case insensitive, which might lead to different canonicalizations if the user is not aware of this problem.</li>
       <li>User communities ought to agree to use lower case
-        <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tags</a>,
+        <a data-cite="RDF11-CONCEPTS#dfn-language-tag">language tags</a>,
         while being aware that some implementations might normalize language tags,
         affecting hash values.</li>
       <li>Future evolution of RDF might regulate this issue, which RDF environments might have to adapt to,
@@ -1064,8 +1064,8 @@
               and associated canonical identifiers.</p>
           </details>
           <div class="issue" data-number="155">
-            [[RDF12-CONCEPTS]] allows implementations to convert
-            <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tags</a> to lower case
+            [[RDF11-CONCEPTS]] allows implementations to convert
+            <a data-cite="RDF11-CONCEPTS#dfn-language-tag">language tags</a> to lower case
             leading to different canonical forms of <a data-cite="RDF11-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>.
             A possible solution is to require that all triples including a
             <a data-cite="RDF11-CONCEPTS#dfn-language-tagged-string">language-tagged string</a>
@@ -3539,7 +3539,7 @@ disclose.
         as appropriate.
         <div class="issue" data-number="155">
           [[RDF11-CONCEPTS]] allows implementations to convert
-          <a data-cite="RDF11-CONCEPTS#dfn-language-tag">language tags</a>
+          <a data-cite="RDF11-CONCEPTS#dfn-language-tag">language tags</a>.
           This represents a potential interoperability issue if language tags
           are not converted to lower case uniformly, as different implementations
           might end up using different canonical representations of such language tags.

--- a/spec/index.html
+++ b/spec/index.html
@@ -1063,8 +1063,6 @@
               <a>input dataset</a> with both their original identifiers,
               and associated canonical identifiers.</p>
           </details>
-            interoperability issue.
-          </div>
         </li>
         <li id="ca.2">For every <a>quad</a> <var>Q</var> in <a>input dataset</a>:
           <ol>

--- a/spec/index.html
+++ b/spec/index.html
@@ -191,6 +191,28 @@
     <strong>RDF Canonicalization algorithm version 1.0</strong> or
     <a>RDFC-1.0</a>.</p>
 
+  <div class="note">
+    <p>[[[RDF11-CONCEPTS]]] [[RDF11-CONCEPTS]] lacks clarity on the representation of
+      <a data-cite="RDF11-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>,
+      where <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tags</a> of the form `xx-YY`
+      are treated as being case insensitive. Impelementations may represent language tags
+      using all lower case in the form `xx-yy`,
+      retain the original representation `xx-YY`,
+      or use [[BCP47]] <a data-cite="BCP47#section-2.1.1">formatting conventions</a>,
+      leading to different canonical forms, and therefore, different hashed values.</p>
+    <ul>
+      <li>The Canonicalization algorithm is based on the RDF 1.1 definition,
+        in the sense that the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> `xx-YY`
+        is case insensitive, which may lead to different canonicalizations if the user is not aware of this problem.</li>
+      <li>User communities should agree to use an agreed-upon choice between upper case or lower case
+        <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>,
+        while being aware that some implementations may normalize language tags,
+        affecting hash values.</li>
+      <li>Future evolution of RDF might regulate this issue, which RDF environments may have to adapt to,
+        and this may lead to an update of <a>RDFC-1.0</a>.</li>
+    </ul>
+    
+  </div>
   <p class="note">See <a href="#urdna2015" class="sectionRef"></a>
     for a comparison with the version of the algorithm published
     in [[[CCG-RDC-FINAL]]] [[CCG-RDC-FINAL]].</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1041,6 +1041,16 @@
               <a>input dataset</a> with both their original identifiers,
               and associated canonical identifiers.</p>
           </details>
+          <div class="issue" data-number="155">
+            [[RDF12-CONCEPTS]] allows implementations to convert
+            <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tags</a> to lower case
+            leading to different canonical forms of <a data-cite="RDF11-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>.
+            A possible solution is to require that all triples including a
+            <a data-cite="RDF11-CONCEPTS#dfn-language-tagged-string">language-tagged string</a>
+            be represented using only a lower case <a data-cite="RDF11-CONCEPTS#dfn-language-tag">language tag</a>.
+            Alternatively, the algorithm could simply detect such language tags and warn about the potential
+            interoperability issue.
+          </div>
         </li>
         <li id="ca.2">For every <a>quad</a> <var>Q</var> in <a>input dataset</a>:
           <ol>
@@ -3499,9 +3509,19 @@ disclose.
       and <code>graphLabel</code>,
       each of which MUST be a single space (<code>U+0020</code>).</li>
     <li><a data-cite="RDF11-CONCEPTS#dfn-literal">Literals</a> with the
-      datatype <code>http://www.w3.org/2001/XMLSchema#string</code>
+      datatypes <code>http://www.w3.org/2001/XMLSchema#string</code> and
+      <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#langString</code>
       MUST NOT use the datatype IRI part of the <a data-cite="N-QUADS#grammar-production-literal">literal</a>,
-      and are represented using only <a data-cite="N-QUADS#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.
+      and are represented using only <a data-cite="N-QUADS#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>
+        and <a href="N-QUADS#grammar-production-LANGTAG">LANGTAG</a>,
+        as appropriate.
+        <div class="issue" data-number="155">
+          [[RDF11-CONCEPTS]] allows implementations to convert
+          <a data-cite="RDF11-CONCEPTS#dfn-language-tag">language tags</a>
+          This represents a potential interoperability issue if language tags
+          are not converted to lower case uniformly, as different implementations
+          may end up using different canonical representations of such language tags.
+        </div>
     </li>
     <li><code><a data-cite="N-QUADS#grammar-production-HEX">HEX</a></code> MUST use only uppercase letters (<code>[A-F]</code>).</li>
     <li>Within <a data-cite="N-QUADS#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,

--- a/spec/index.html
+++ b/spec/index.html
@@ -195,7 +195,7 @@
     <p>[[[RDF11-CONCEPTS]]] [[RDF11-CONCEPTS]] lacks clarity on the representation of
       <a data-cite="RDF11-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>,
       where <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tags</a> of the form `xx-YY`
-      are treated as being case insensitive. Impelementations may represent language tags
+      are treated as being case insensitive. Implementations might represent language tags
       using all lower case in the form `xx-yy`,
       retain the original representation `xx-YY`,
       or use [[BCP47]] <a data-cite="BCP47#section-2.1.1">formatting conventions</a>,
@@ -203,13 +203,13 @@
     <ul>
       <li>The Canonicalization algorithm is based on the RDF 1.1 definition,
         in the sense that the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> `xx-YY`
-        is case insensitive, which may lead to different canonicalizations if the user is not aware of this problem.</li>
-      <li>User communities should agree to use an agreed-upon choice between upper case or lower case
-        <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>,
-        while being aware that some implementations may normalize language tags,
+        is case insensitive, which might lead to different canonicalizations if the user is not aware of this problem.</li>
+      <li>User communities ought to agree to use lower case
+        <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tags</a>,
+        while being aware that some implementations might normalize language tags,
         affecting hash values.</li>
-      <li>Future evolution of RDF might regulate this issue, which RDF environments may have to adapt to,
-        and this may lead to an update of <a>RDFC-1.0</a>.</li>
+      <li>Future evolution of RDF might regulate this issue, which RDF environments might have to adapt to,
+        and this might lead to an update of <a>RDFC-1.0</a>.</li>
     </ul>
     
   </div>

--- a/spec/index.html
+++ b/spec/index.html
@@ -3578,7 +3578,7 @@ disclose.
     The minor change is in the <a>canonical n-quads form</a> where
     some control characters were previously represented without escaping.
     The version of the algorithm defined in <a href="#canonical-quads" class="sectionRef"></a>
-    clarifies the representation of <a data-cite="RDF11-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a> and the characters
+    clarifies the representation of <a data-cite="RDF11-CONCEPTS#dfn-simple-literal">simple literals</a> and the characters
     within <a data-cite="N-QUADS#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>
     that are encoded using <code><a data-cite="N-QUADS#grammar-production-ECHAR">ECHAR</a></code>.</p>
 </section>


### PR DESCRIPTION
Adds text similar to that proposed for N-Quads on not using a datatype when canonically representing language-tagged strings and issue marker to #155.

Also add an issue marker to the first step in the canonicalization algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/156.html" title="Last updated on Aug 10, 2023, 3:58 PM UTC (26bc45c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/156/1a42cea...26bc45c.html" title="Last updated on Aug 10, 2023, 3:58 PM UTC (26bc45c)">Diff</a>