### PR TITLE
Add contributors to the CCG final report

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -3690,7 +3690,20 @@ disclose.
     justification of the development of <a>RDFC-1.0</a>.</p>
   <p data-include="common/participants.html"></p>
 
-  <p class="issue" data-number="114"></p>
+  <p>This specification is based on work done in the
+    <a href="https://www.w3.org/community/credentials/">W3C Credentials Community Group</a>
+    published as [[CCG-RDC-FINAL]].
+    Contributors to the Community Group Final Report include:
+    Blake Regalia,
+    Dave Longley,
+    David Lehn,
+    David Lozano Jarque,
+    Gregg Kellogg,
+    Manu Sporny,
+    Markus Sabadello,
+    Matt Collier, and
+    Sebastian Schmittner.
+  </p>
 </section>
 
 </body>


### PR DESCRIPTION
Based on GitHub contributions to https://github.com/w3c-ccg/rdf-dataset-canonicalization. The list of people contributing to the original normalization document in https://github.com/json-ld/json-ld.org is a subset of those working on the CG document.

Contributors to the Community Group Final Report include: Blake Regalia, Dave Longley, David Lehn, David Lozano Jarque, Gregg Kellogg, Manu Sporny, Markus Sabadello, Matt Collier, and Sebastian Schmittner (in alphabetical order).


Fixes #114.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/158.html" title="Last updated on Aug 16, 2023, 8:22 PM UTC (c59c477)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/158/27a94b3...c59c477.html" title="Last updated on Aug 16, 2023, 8:22 PM UTC (c59c477)">Diff</a>