### PR TITLE
Add security section about insecure hashing algorithms.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -2884,6 +2884,17 @@ disclose.
     </p>
   </section>
 
+  <section id="insecure-hashing-algorithms" class="informative">
+    <h3>Insecure Hashing Algorithms</h3>
+
+    <p>It is possible that the hashing algorithm used by RDFC-1.0 may become
+      insecure at some point in the future. To mitigate this, this algorithm
+      and implementations of it can be parameterized to use a different
+      hashing function, without the need to make any changes to the
+      canonicalization algorithm itself.
+    </p>
+  </section>
+
 </section>
 
 <section id="use-cases" class="informative">


### PR DESCRIPTION
An attempt to add a note about hashing algorithms becoming insecure, to address one of the comments in the TAG review in https://github.com/w3ctag/design-reviews/issues/855#issuecomment-1664350113.