### PR TITLE
Update the earl report for a Rust implementation (zkp-ld/rdf-canon)

### DIFF
--- a/reports/earl.jsonld
+++ b/reports/earl.jsonld
@@ -204,7 +204,7 @@
       "language": "Rust",
       "release": {
         "@id": "_:b452",
-        "revision": "0.13.0"
+        "revision": "0.14.0"
       }
     },
     {
@@ -495,12 +495,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test003-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b617",
+              "@id": "_:b621",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003m",
               "result": {
-                "@id": "_:b618",
+                "@id": "_:b622",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -632,12 +632,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test004-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b619",
+              "@id": "_:b623",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004m",
               "result": {
-                "@id": "_:b620",
+                "@id": "_:b624",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -769,12 +769,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test005-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b621",
+              "@id": "_:b625",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005m",
               "result": {
-                "@id": "_:b622",
+                "@id": "_:b626",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -1389,12 +1389,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test016-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b623",
+              "@id": "_:b627",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016m",
               "result": {
-                "@id": "_:b624",
+                "@id": "_:b628",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -1526,12 +1526,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test017-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b625",
+              "@id": "_:b629",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017m",
               "result": {
-                "@id": "_:b626",
+                "@id": "_:b630",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -1663,12 +1663,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test018-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b627",
+              "@id": "_:b631",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018m",
               "result": {
-                "@id": "_:b628",
+                "@id": "_:b632",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -1869,12 +1869,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test020-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b629",
+              "@id": "_:b633",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020m",
               "result": {
-                "@id": "_:b630",
+                "@id": "_:b634",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -2627,12 +2627,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test030-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b631",
+              "@id": "_:b635",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030m",
               "result": {
-                "@id": "_:b632",
+                "@id": "_:b636",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -3526,12 +3526,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test047-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b633",
+              "@id": "_:b637",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047m",
               "result": {
-                "@id": "_:b634",
+                "@id": "_:b638",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -3663,12 +3663,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test048-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b635",
+              "@id": "_:b639",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048m",
               "result": {
-                "@id": "_:b636",
+                "@id": "_:b640",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -3802,12 +3802,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test053-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b637",
+              "@id": "_:b641",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053m",
               "result": {
-                "@id": "_:b638",
+                "@id": "_:b642",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -4008,12 +4008,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test055-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b639",
+              "@id": "_:b643",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055m",
               "result": {
-                "@id": "_:b640",
+                "@id": "_:b644",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -4145,12 +4145,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test056-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b641",
+              "@id": "_:b645",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056m",
               "result": {
-                "@id": "_:b642",
+                "@id": "_:b646",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -4282,12 +4282,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test057-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b643",
+              "@id": "_:b647",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057m",
               "result": {
-                "@id": "_:b644",
+                "@id": "_:b648",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -4557,12 +4557,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test060-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b645",
+              "@id": "_:b649",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060m",
               "result": {
-                "@id": "_:b646",
+                "@id": "_:b650",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -4834,12 +4834,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test063-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b647",
+              "@id": "_:b651",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063m",
               "result": {
-                "@id": "_:b648",
+                "@id": "_:b652",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -5317,12 +5317,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test070-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b649",
+              "@id": "_:b653",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test070c",
               "result": {
-                "@id": "_:b650",
+                "@id": "_:b654",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -5386,12 +5386,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test070-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b651",
+              "@id": "_:b655",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test070m",
               "result": {
-                "@id": "_:b652",
+                "@id": "_:b656",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -5455,12 +5455,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test071-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b653",
+              "@id": "_:b657",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test071c",
               "result": {
-                "@id": "_:b654",
+                "@id": "_:b658",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -5524,12 +5524,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test071-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b655",
+              "@id": "_:b659",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test071m",
               "result": {
-                "@id": "_:b656",
+                "@id": "_:b660",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -5593,12 +5593,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test072-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b657",
+              "@id": "_:b661",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test072c",
               "result": {
-                "@id": "_:b658",
+                "@id": "_:b662",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -5662,12 +5662,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test072-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b659",
+              "@id": "_:b663",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test072m",
               "result": {
-                "@id": "_:b660",
+                "@id": "_:b664",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -5731,12 +5731,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test073-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b661",
+              "@id": "_:b665",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test073c",
               "result": {
-                "@id": "_:b662",
+                "@id": "_:b666",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -5800,12 +5800,12 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test073-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b663",
+              "@id": "_:b667",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test073m",
               "result": {
-                "@id": "_:b664",
+                "@id": "_:b668",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -5868,12 +5868,12 @@
           "testAction": "https://w3c.github.io/rdf-canon/tests/rdfc10/test074-in.nq",
           "assertions": [
             {
-              "@id": "_:b665",
+              "@id": "_:b669",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test074c",
               "result": {
-                "@id": "_:b666",
+                "@id": "_:b670",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
@@ -5938,28 +5938,29 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test075-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b667",
+              "@id": "_:b671",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075c",
               "result": {
-                "@id": "_:b668",
+                "@id": "_:b672",
                 "@type": "TestResult",
                 "outcome": "earl:untested"
               },
               "assertedBy": null
             },
             {
-              "@id": "_:b669",
+              "@id": "_:b617",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075c",
+              "assertedBy": "https://github.com/yamdan",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b670",
+                "@id": "_:b618",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
               "@id": "_:b165",
@@ -6007,21 +6008,9 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test075-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b671",
-              "@type": "Assertion",
-              "subject": "https://github.com/pchampin/sophia_rs",
-              "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075m",
-              "result": {
-                "@id": "_:b672",
-                "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
-            },
-            {
               "@id": "_:b673",
               "@type": "Assertion",
-              "subject": "https://github.com/zkp-ld/rdf-canon",
+              "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075m",
               "result": {
                 "@id": "_:b674",
@@ -6029,6 +6018,19 @@
                 "outcome": "earl:untested"
               },
               "assertedBy": null
+            },
+            {
+              "@id": "_:b619",
+              "@type": "Assertion",
+              "subject": "https://github.com/zkp-ld/rdf-canon",
+              "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075m",
+              "assertedBy": "https://github.com/yamdan",
+              "mode": "earl:automatic",
+              "result": {
+                "@id": "_:b620",
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
             },
             {
               "@id": "_:b167",

--- a/reports/earl.ttl
+++ b/reports/earl.ttl
@@ -3730,8 +3730,9 @@
     earl:subject <https://github.com/zkp-ld/rdf-canon> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://github.com/yamdan> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test075c> ;
@@ -3774,8 +3775,9 @@
     earl:subject <https://github.com/zkp-ld/rdf-canon> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <https://github.com/yamdan> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test075m> ;
@@ -3813,7 +3815,7 @@
   doap:homepage <https://github.com/zkp-ld/rdf-canon> ;
   doap:description "A Rust implementation of the RDF Dataset Canonicalization algorithm version 1.0 (RDFC-1.0) compatible with Oxigraph and Oxrdf."@en ;
   doap:programming-language "Rust" ;
-  doap:release [doap:revision "0.13.0"] .
+  doap:release [doap:revision "0.14.0"] .
 
 <https://github.com/yamdan> a foaf:Person, earl:Assertor ;
   foaf:name "Dan Yamamoto" .

--- a/reports/index.html
+++ b/reports/index.html
@@ -1739,8 +1739,8 @@ PASS
 <td class='UNTESTED'>
 UNTESTED
 </td>
-<td class='UNTESTED'>
-UNTESTED
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1756,8 +1756,8 @@ PASS
 <td class='UNTESTED'>
 UNTESTED
 </td>
-<td class='UNTESTED'>
-UNTESTED
+<td class='PASS'>
+PASS
 </td>
 <td class='PASS'>
 PASS
@@ -1773,8 +1773,8 @@ Percentage passed out of 84 Tests
 <td class='passed-some'>
 67.9%
 </td>
-<td class='passed-most'>
-97.6%
+<td class='passed-all'>
+100.0%
 </td>
 <td class='passed-all'>
 100.0%
@@ -1853,7 +1853,7 @@ Test Suite Compliance
 <dt>Description</dt>
 <dd lang='en' property='doap:description'>A Rust implementation of the RDF Dataset Canonicalization algorithm version 1.0 (RDFC-1.0) compatible with Oxigraph and Oxrdf.</dd>
 <dt>Release</dt>
-<dd property='doap:release'><span property='doap:revision'>0.13.0</span></dd>
+<dd property='doap:release'><span property='doap:revision'>0.14.0</span></dd>
 <dt>Programming Language</dt>
 <dd property='doap:programming-language'>Rust</dd>
 <dt>Home Page</dt>
@@ -1880,8 +1880,8 @@ Test Suite Compliance
 <td>
 
 </td>
-<td class='passed-most'>
-82/84 (97.6%)
+<td class='passed-all'>
+84/84 (100.0%)
 </td>
 </tr>
 </tbody>

--- a/reports/rust-zkp-ld-earl.ttl
+++ b/reports/rust-zkp-ld-earl.ttl
@@ -7,14 +7,14 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 
 <> foaf:primaryTopic <https://github.com/zkp-ld/rdf-canon> ;
-  dc:issued "2023-08-15"^^xsd:date ;
+  dc:issued "2023-09-06"^^xsd:date ;
   foaf:maker <https://github.com/yamdan> .
 
 <https://github.com/zkp-ld/rdf-canon> a doap:Project ;
   doap:name                 "zkp-ld/rdf-canon" ;
-  doap:release              [ doap:name     "zkp-ld/rdf-canon-0.13.0" ;
-                              doap:revision "0.13.0" ;
-                              doap:created  "2023-08-02"^^xsd:date ;
+  doap:release              [ doap:name     "zkp-ld/rdf-canon-0.14.0" ;
+                              doap:revision "0.14.0" ;
+                              doap:created  "2023-09-01"^^xsd:date ;
                             ] ;
   doap:developer            <https://github.com/yamdan> ;
   doap:description          "A Rust implementation of the RDF Dataset Canonicalization algorithm version 1.0 (RDFC-1.0) compatible with Oxigraph and Oxrdf."@en ;
@@ -31,7 +31,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test001c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -42,7 +42,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test002c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -53,7 +53,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test003c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -64,7 +64,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test003m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -75,7 +75,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test004c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -86,7 +86,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test004m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -97,7 +97,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test005c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -108,7 +108,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test005m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -119,7 +119,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test006c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -130,7 +130,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test008c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -141,7 +141,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test009c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -152,7 +152,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test010c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -163,7 +163,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test011c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -174,7 +174,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test013c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -185,7 +185,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test014c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -196,7 +196,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test016c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -207,7 +207,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test016m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -218,7 +218,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test017c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -229,7 +229,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test017m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -240,7 +240,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test018c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -251,7 +251,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test018m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -262,7 +262,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test019c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -273,7 +273,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test020c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -284,7 +284,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test020m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -295,7 +295,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test021c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -306,7 +306,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test022c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -317,7 +317,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test023c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -328,7 +328,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test024c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -339,7 +339,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test025c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -350,7 +350,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test026c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -361,7 +361,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test027c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -372,7 +372,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test028c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -383,7 +383,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test029c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -394,7 +394,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test030c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -405,7 +405,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test030m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -416,7 +416,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test033c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -427,7 +427,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test034c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -438,7 +438,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test035c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -449,7 +449,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test036c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -460,7 +460,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test038c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -471,7 +471,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test039c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -482,7 +482,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test040c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -493,7 +493,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test043c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -504,7 +504,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test044c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -515,7 +515,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test045c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -526,7 +526,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test046c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -537,7 +537,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test047c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -548,7 +548,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test047m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -559,7 +559,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test048c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -570,7 +570,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test048m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -581,7 +581,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test053c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -592,7 +592,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test053m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -603,7 +603,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test054c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -614,7 +614,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test055c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -625,7 +625,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test055m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -636,7 +636,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test056c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -647,7 +647,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test056m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -658,7 +658,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test057c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -669,7 +669,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test057m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -680,7 +680,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test058c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -691,7 +691,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test059c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -702,7 +702,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test060c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -713,7 +713,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test060m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -724,7 +724,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test061c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -735,7 +735,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test062c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -746,7 +746,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test063c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -757,7 +757,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test063m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -768,7 +768,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test064c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -779,7 +779,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test065c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -790,7 +790,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test066c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -801,7 +801,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test067c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -812,7 +812,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test068c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -823,7 +823,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test069c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -834,7 +834,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test070c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -845,7 +845,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test070m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -856,7 +856,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test071c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -867,7 +867,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test071m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -878,7 +878,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test072c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -889,7 +889,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test072m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -900,7 +900,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test073c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -911,7 +911,7 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test073m> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .
@@ -922,7 +922,29 @@
   earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test074c> ;
   earl:result     [ a            earl:TestResult ;
                     earl:outcome earl:passed ;
-                    dc:date      "2023-08-15T11:03:02Z"^^xsd:dateTime 
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
+                  ] ;
+  earl:mode     earl:automatic 
+] .
+
+[ a               earl:Assertion ;
+  earl:assertedBy <https://github.com/yamdan> ;
+  earl:subject    <https://github.com/zkp-ld/rdf-canon> ;
+  earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test075c> ;
+  earl:result     [ a            earl:TestResult ;
+                    earl:outcome earl:passed ;
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
+                  ] ;
+  earl:mode     earl:automatic 
+] .
+
+[ a               earl:Assertion ;
+  earl:assertedBy <https://github.com/yamdan> ;
+  earl:subject    <https://github.com/zkp-ld/rdf-canon> ;
+  earl:test       <https://w3c.github.io/rdf-canon/tests/manifest#test075m> ;
+  earl:result     [ a            earl:TestResult ;
+                    earl:outcome earl:passed ;
+                    dc:date      "2023-09-06T03:16:07Z"^^xsd:dateTime 
                   ] ;
   earl:mode     earl:automatic 
 ] .


### PR DESCRIPTION
This includes the latest test result regarding to SHA-384.