### PR TITLE
Add some caveats about changing the default hash algorithm

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -270,7 +270,9 @@
       As a result, a graph signature can be obtained by hashing a canonical serialization
       of the resulting <a>canonicalized dataset</a>,
       allowing for the isomorphism and digital signing use cases.
-      As blank node identifiers can be stable even with other changes to a graph (dataset),
+      This algorithm does not define such a graph signature.</p>
+
+    <p>As blank node identifiers can be stable even with other changes to a graph (dataset),
       in some cases it is possible to compute the difference between two graphs (datasets),
       for example if changes are made only to ground triples,
       or if new blank nodes are introduced which do not create an automorphic confusion
@@ -281,6 +283,15 @@
       it may be possible to correlate the original blank node identifiers
       used within that N-Quads document with those issued in the
       <a>canonicalized dataset</a>.</p>
+
+    <p class="note">Although alternative <a>hash algorithms</a> may be used
+      with this specification,
+      applications should carfully weigh the advantages
+      and disadvantates of using an alternative hash function.
+      In particular, any representation of the <a>canonical n-quads form</a>
+      or <a>issued identifiers map</a>
+      without identifying the associated hash algorithm.
+    </p>
   </section>
 
   <section id="how-to-read">
@@ -375,6 +386,9 @@
           and SHOULD support the ability to specify other hash algorithms.
           Using a different hash algorithm will generally result in different output than
           using the default.</p>
+
+        <p class="note">There is no expectation that the default hash function
+          is also used to create a hash signature of the canonical N-Quads result.</p>
       </dd>
       <dt><dfn>mention</dfn></dt>
       <dd>
@@ -2881,8 +2895,15 @@
       and implementations of it can be parameterized to use a different
       hash function, without the need to make any changes to the
       canonicalization algorithm itself.
-      However, using a different hash algorithm will generally lead to different results.
+      However, using a different hash algorithm will generally lead to different results;
+      applications making use of this specification should carfully weigh the advantages
+      and disadvantates of using an alternative hash function.
     </p>
+
+    <p class="note">The possible implications of the default hash algorithm
+      becoming insecure are mitegated by that fact that no internal hash
+      values are revealed, and the algorithms are designed to cope
+      with hash collisions.</p>
   </section>
 
 </section>


### PR DESCRIPTION
and advice on keeping the algorithm used along with any results.

(Note, when this PR is created, spec-prod is having some issues resolving aspects of the document, so the PR Preview link might show errors. This [GitHack](https://raw.githack.com/w3c/rdf-canon/hash-algo-clarifications/spec/index.html) version may provide better results).

Fixes #176.