### PR TITLE
fix broken links to externally defined terms

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1102,7 +1102,7 @@
                   As noted in
                   <a data-cite="RDF11-CONCEPTS#section-Graph-Literal">Section 3.3</a>
                   of [[RDF11-CONCEPTS]],
-                  <a data-cite="RDF11-CONCEPTS#dfn-term-equal">literal term equality</a>
+                  <a data-cite="RDF11-CONCEPTS#dfn-literal-term-equality">literal term equality</a>
                   is based on the
                   <a data-cite="RDF11-CONCEPTS#dfn-lexical-form">lexical form</a>,
                   rather than the <a data-cite="RDF11-CONCEPTS#dfn-literal-value">literal value</a>,
@@ -3577,8 +3577,8 @@
           MUST be represented by their native [[UNICODE]] representation.</li>
       </ul>
      </li>
-    <li>The token <code><a href="N-QUADS#grammar-production-EOL">EOL</a></code> MUST be a single <code>LF</code> (line feed, code point <code class="codepoint">U+000A</code>).</li>
-    <li>The final <code><a href="N-QUADS#grammar-production-EOL">EOL</a></code> MUST be provided.</li>
+    <li>The token <code><a data-cite="N-QUADS#grammar-production-EOL">EOL</a></code> MUST be a single <code>LF</code> (line feed, code point <code class="codepoint">U+000A</code>).</li>
+    <li>The final <code><a data-cite="N-QUADS#grammar-production-EOL">EOL</a></code> MUST be provided.</li>
   </ul>  
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -26,7 +26,7 @@
     // only "name" is required
     editors:  [
       { name:       "Dave Longley",
-        url:        "https://digitalbazaar.com/author/dlongley/",
+        url:        "https://github.com/dlongley",
         w3cid:      "48025",
         company:    "Digital Bazaar",
         companyURL: "https://digitalbazaar.com/" },
@@ -42,7 +42,7 @@
     // only "name" is required
     formerEditors:  [
       { name:       "Manu Sporny",
-        url:        "http://manu.sporny.org/",
+        url:        "https://github.com/msporny",
         w3cid:      "41758",
         company:    "Digital Bazaar",
         companyURL: "https://digitalbazaar.com/",
@@ -54,7 +54,7 @@
     // only "name" is required. Same format as editors.
     authors:  [
       { name:       "Dave Longley",
-        url:        "https://digitalbazaar.com/author/dlongley/",
+        url:        "https://github.com/dlongley",
         w3cid:      "48025",
         company:    "Digital Bazaar",
         companyURL: "https://digitalbazaar.com/" }


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/179.html" title="Last updated on Oct 16, 2023, 4:30 PM UTC (0b126a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/179/e80c1dd...0b126a2.html" title="Last updated on Oct 16, 2023, 4:30 PM UTC (0b126a2)">Diff</a>