### PR TITLE
Add CR exit criteria.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -62,6 +62,7 @@
 
     // name of the
     group: "rch",
+    crEnd: "2023-11-20",
     testSuiteURI: "https://w3c.github.io/rdf-canon/tests/",
     implementationReportURI: "https://w3c.github.io/rdf-canon/reports/",
     xref: ["infra"],
@@ -151,6 +152,11 @@
     normatively in this specification with the expectation
     that a future update to this specification will replace those with normative
     references to updated RDF specifications.</p>
+
+  <p>To successfully advance to Proposed Recommendation,
+    each test in the <a href="https://w3c.github.io/rdf-canon/tests/">test suite</a>
+    MUST be passed by at least three independent implementations.
+    Two independent implementations MUST pass all tests.</p>
 </section>
 
 <section id="introduction" class="informative">


### PR DESCRIPTION
Adds text to SOTD stating implementation requirements to pass to PR. (Note, this will need to be removed or modified after CR). Somewhat arbitrarily sets the CR Exit date to 2023-11-20.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/180.html" title="Last updated on Oct 13, 2023, 5:20 PM UTC (4ef75a4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/180/5ca4c04...4ef75a4.html" title="Last updated on Oct 13, 2023, 5:20 PM UTC (4ef75a4)">Diff</a>