### PR TITLE
Fix report developer homepage link.

### DIFF
--- a/reports/earl.jsonld
+++ b/reports/earl.jsonld
@@ -135,7 +135,7 @@
       "name": "earl-report-0.9.0",
       "doap:created": {
         "@type": "http://www.w3.org/2001/XMLSchema#date",
-        "@value": "2023-09-16"
+        "@value": "2023-11-16"
       },
       "revision": "0.9.0"
     },

--- a/reports/earl.ttl
+++ b/reports/earl.ttl
@@ -3801,5 +3801,5 @@
 
 <https://github.com/gkellogg/earl-report/tree/0.9.0> a doap:Version;
   doap:name "earl-report-0.9.0";
-  doap:created "2023-09-16"^^xsd:date;
+  doap:created "2023-11-16"^^xsd:date;
   doap:revision "0.9.0" .

--- a/reports/index.html
+++ b/reports/index.html
@@ -93,8 +93,8 @@
         EARL results from the RDF Dataset Canonicalization and Hash 1.0 Test Suite
       </h2>
       <h2 id='w3c-document-28-october-2015'>
-        <time class='dt-published' datetime='2023-09-16' property='dc:issued'>
-          16 September 2023
+        <time class='dt-published' datetime='2023-11-16' property='dc:issued'>
+          16 November 2023
         </time>
       </h2>
       <dl>

--- a/reports/template.haml
+++ b/reports/template.haml
@@ -381,8 +381,9 @@
                       - else
                         %span{property: "foaf:name"}<
                       - if dev['foaf:homepage']
-                        %a{property: "foaf:homepage", href: dev['foaf:homepage']}
-                          ~ CGI.escapeHTML dev['foaf:homepage'].is_a?(Hash) ? dev['foaf:homepage']['@id'] : dev['foaf:homepage']
+                        - href = dev['foaf:homepage'].is_a?(Hash) ? dev['foaf:homepage']['@id'] : dev['foaf:homepage']
+                        %a{property: "foaf:homepage", href: href}
+                          ~ CGI.escapeHTML href.to_s
               %dt
                 Test Suite Compliance
               %dd


### PR DESCRIPTION
Use the the same object check for developer homepage text and link href.

I've never written haml before, so this is a best guess at using a local var.  The to_s was used above so I did the same.  Please adjust as needed.

This is an issue for the Digital Bazaar rdf-canonize report which has a HTTPRange-14 related issue and uses the same developer id and homepage, resulting in an object for the homepage, and the JSON was getting encoded as a URL.

I'd also be nice to put parens around the homepage or something to make it clear there are two links.  I failed to figure out how to do that and make it look good.  Something like:
`Ima Developer (https://example.com/)`