### PR TITLE
Updated the rdfjs-c14n earl report

### DIFF
--- a/reports/earl.jsonld
+++ b/reports/earl.jsonld
@@ -135,7 +135,7 @@
       "name": "earl-report-0.9.0",
       "doap:created": {
         "@type": "http://www.w3.org/2001/XMLSchema#date",
-        "@value": "2023-11-16"
+        "@value": "2023-11-23"
       },
       "revision": "0.9.0"
     },
@@ -267,7 +267,7 @@
       "language": "TypeScript",
       "release": {
         "@id": "_:b169",
-        "revision": "2.0.5"
+        "revision": "3.0.0"
       }
     },
     {

--- a/reports/earl.ttl
+++ b/reports/earl.ttl
@@ -4539,7 +4539,7 @@
   doap:homepage <https://iherman.github.io/rdfjs-c14n/> ;
   doap:description "Implementation in Typescript of the RDF Canonicalization Algorithm RDFC-1.0, on top of the RDF/JS interfaces"@en ;
   doap:programming-language "TypeScript" ;
-  doap:release [doap:revision "2.0.5"] .
+  doap:release [doap:revision "3.0.0"] .
 
 <https://www.ivan-herman.net/foaf#me> a foaf:Person, earl:Assertor ;
   foaf:name "Ivan Herman" ;
@@ -4571,5 +4571,5 @@
 
 <https://github.com/gkellogg/earl-report/tree/0.9.0> a doap:Version;
   doap:name "earl-report-0.9.0";
-  doap:created "2023-11-16"^^xsd:date;
+  doap:created "2023-11-23"^^xsd:date;
   doap:revision "0.9.0" .

--- a/reports/index.html
+++ b/reports/index.html
@@ -94,8 +94,8 @@
         EARL results from the RDF Dataset Canonicalization and Hash 1.0 Test Suite
       </h2>
       <h2 id='w3c-document-28-october-2015'>
-        <time class='dt-published' datetime='2023-11-16' property='dc:issued'>
-          16 November 2023
+        <time class='dt-published' datetime='2023-11-23' property='dc:issued'>
+          23 November 2023
         </time>
       </h2>
       <dl>
@@ -1968,7 +1968,7 @@
             <dt>Description</dt>
             <dd lang='en' property='doap:description'>Implementation in Typescript of the RDF Canonicalization Algorithm RDFC-1.0, on top of the RDF/JS interfaces</dd>
             <dt>Release</dt>
-            <dd property='doap:release'><span property='doap:revision'>2.0.5</span></dd>
+            <dd property='doap:release'><span property='doap:revision'>3.0.0</span></dd>
             <dt>Programming Language</dt>
             <dd property='doap:programming-language'>TypeScript</dd>
             <dt>Home Page</dt>

--- a/reports/rdfjs-c14n-report.ttl
+++ b/reports/rdfjs-c14n-report.ttl
@@ -7,7 +7,7 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 
 <> foaf:primaryTopic <https://iherman.github.io/rdfjs-c14n/> ;
-  dc:issued  "2023-09-05T14:15:57.885Z"^^xsd:dateTime ;
+  dc:issued  "2023-11-23T15:02:00.487Z"^^xsd:dateTime ;
   foaf:maker <https://www.ivan-herman.net/foaf#me> .
 
 <https://iherman.github.io/rdfjs-c14n/> a doap:Project ;
@@ -31,8 +31,8 @@
   doap:release [
     a doap:Version ;
     doap:name     "rdfjs-c14n";
-    doap:revision "2.0.5";
-    doap:created  "2023-09-05"^^xsd:date ;
+    doap:revision "3.0.0";
+    doap:created  "2023-11-23"^^xsd:date ;
   ] ;
   doap:repository [
     a doap:GitRepository ;
@@ -53,7 +53,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -66,7 +66,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -79,7 +79,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -92,7 +92,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -105,7 +105,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -118,7 +118,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -131,7 +131,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -144,7 +144,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -157,7 +157,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -170,7 +170,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -183,7 +183,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -196,7 +196,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -209,7 +209,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -222,7 +222,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -235,7 +235,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -248,7 +248,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -261,7 +261,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -274,7 +274,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -287,7 +287,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -300,7 +300,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -313,7 +313,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -326,7 +326,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -339,7 +339,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -352,7 +352,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -365,7 +365,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -378,7 +378,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -391,7 +391,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -404,7 +404,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -417,7 +417,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -430,7 +430,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -443,7 +443,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -456,7 +456,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -469,7 +469,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -482,7 +482,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -495,7 +495,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -508,7 +508,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -521,7 +521,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -534,7 +534,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -547,7 +547,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -560,7 +560,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -573,7 +573,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -586,7 +586,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -599,7 +599,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -612,7 +612,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -625,7 +625,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -638,7 +638,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -651,7 +651,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -664,7 +664,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -677,7 +677,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -690,7 +690,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -703,7 +703,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -716,7 +716,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -729,7 +729,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -742,7 +742,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -755,7 +755,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -768,7 +768,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -781,7 +781,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -794,7 +794,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -807,7 +807,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -820,7 +820,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -833,7 +833,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -846,7 +846,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -859,7 +859,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -872,7 +872,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -885,7 +885,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -898,7 +898,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -911,7 +911,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -924,7 +924,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -937,7 +937,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -950,7 +950,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -963,7 +963,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -976,7 +976,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -989,7 +989,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -1002,7 +1002,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -1015,7 +1015,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -1028,7 +1028,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -1041,7 +1041,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -1054,7 +1054,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -1067,7 +1067,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -1080,7 +1080,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -1093,7 +1093,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -1106,7 +1106,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -1119,7 +1119,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .
@@ -1132,7 +1132,7 @@
     earl:result [
         a earl:TestResult ;
         earl:outcome earl:passed ;
-        dc:date      "2023-09-05T14:15:57.885Z"^^xsd:dateTime
+        dc:date      "2023-11-23T15:02:00.487Z"^^xsd:dateTime
     ];
     earl:mode earl:automatic
 ] .


### PR DESCRIPTION
I have updated the implementation (switched to the official WebCrypto API for hashing), and this is the new, corresponding earl report. Only the doam metadata and the test dates have changed.