### PR TITLE
Update rust-sophia-rdfc10.ttl  …

### DIFF
--- a/reports/earl.jsonld
+++ b/reports/earl.jsonld
@@ -135,7 +135,7 @@
       "name": "earl-report-0.9.0",
       "doap:created": {
         "@type": "http://www.w3.org/2001/XMLSchema#date",
-        "@value": "2023-11-23"
+        "@value": "2023-11-28"
       },
       "revision": "0.9.0"
     },
@@ -324,66 +324,66 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test001-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b167",
+              "@id": "_:b1",
               "@type": "Assertion",
               "subject": "https://github.com/digitalbazaar/rdf-canonize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test001c",
               "assertedBy": "https://digitalbazaar.com/",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b168",
+                "@id": "_:b2",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b673",
+              "@id": "_:b507",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test001c",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b674",
+                "@id": "_:b508",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b842",
+              "@id": "_:b676",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test001c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b843",
+                "@id": "_:b677",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b336",
+              "@id": "_:b170",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test001c",
               "assertedBy": "https://www.ivan-herman.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b337",
+                "@id": "_:b171",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b505",
+              "@id": "_:b339",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test001c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b506",
+                "@id": "_:b340",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -7149,66 +7149,66 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test075-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b1",
+              "@id": "_:b167",
               "@type": "Assertion",
               "subject": "https://github.com/digitalbazaar/rdf-canonize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075m",
               "assertedBy": "https://digitalbazaar.com/",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b2",
+                "@id": "_:b168",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b507",
+              "@id": "_:b673",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075m",
               "assertedBy": "http://champin.net/#pa",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b508",
+                "@id": "_:b674",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b676",
+              "@id": "_:b842",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b677",
+                "@id": "_:b843",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b170",
+              "@id": "_:b336",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075m",
               "assertedBy": "https://www.ivan-herman.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b171",
+                "@id": "_:b337",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b339",
+              "@id": "_:b505",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b340",
+                "@id": "_:b506",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }

--- a/reports/earl.jsonld
+++ b/reports/earl.jsonld
@@ -239,7 +239,7 @@
       "doapDesc": "A Rust implementation of the RDF Dataset Canonicalization algorithm version 1.0 (RDFC-1.0) compatible with Oxigraph and Oxrdf.",
       "language": "Rust",
       "release": {
-        "@id": "_:b507",
+        "@id": "_:b675",
         "revision": "0.14.0"
       }
     },
@@ -324,65 +324,66 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test001-rdfc10.nq",
           "assertions": [
             {
-              "@id": "_:b1",
+              "@id": "_:b167",
               "@type": "Assertion",
               "subject": "https://github.com/digitalbazaar/rdf-canonize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test001c",
               "assertedBy": "https://digitalbazaar.com/",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b2",
+                "@id": "_:b168",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b676",
+              "@id": "_:b673",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test001c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b677",
+                "@id": "_:b674",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b508",
+              "@id": "_:b842",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test001c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b509",
+                "@id": "_:b843",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b170",
+              "@id": "_:b336",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test001c",
               "assertedBy": "https://www.ivan-herman.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b171",
+                "@id": "_:b337",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b339",
+              "@id": "_:b505",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test001c",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b340",
+                "@id": "_:b506",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -418,26 +419,27 @@
               }
             },
             {
-              "@id": "_:b678",
+              "@id": "_:b509",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test002c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b679",
+                "@id": "_:b510",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b510",
+              "@id": "_:b678",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test002c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b511",
+                "@id": "_:b679",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -499,26 +501,27 @@
               }
             },
             {
-              "@id": "_:b680",
+              "@id": "_:b511",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b681",
+                "@id": "_:b512",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b512",
+              "@id": "_:b680",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b513",
+                "@id": "_:b681",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -580,26 +583,27 @@
               }
             },
             {
-              "@id": "_:b682",
+              "@id": "_:b513",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b683",
+                "@id": "_:b514",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b514",
+              "@id": "_:b682",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test003m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b515",
+                "@id": "_:b683",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -661,26 +665,27 @@
               }
             },
             {
-              "@id": "_:b684",
+              "@id": "_:b515",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b685",
+                "@id": "_:b516",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b516",
+              "@id": "_:b684",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b517",
+                "@id": "_:b685",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -742,26 +747,27 @@
               }
             },
             {
-              "@id": "_:b686",
+              "@id": "_:b517",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b687",
+                "@id": "_:b518",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b518",
+              "@id": "_:b686",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test004m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b519",
+                "@id": "_:b687",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -823,26 +829,27 @@
               }
             },
             {
-              "@id": "_:b688",
+              "@id": "_:b519",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b689",
+                "@id": "_:b520",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b520",
+              "@id": "_:b688",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b521",
+                "@id": "_:b689",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -904,26 +911,27 @@
               }
             },
             {
-              "@id": "_:b690",
+              "@id": "_:b521",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b691",
+                "@id": "_:b522",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b522",
+              "@id": "_:b690",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test005m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b523",
+                "@id": "_:b691",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -985,26 +993,27 @@
               }
             },
             {
-              "@id": "_:b692",
+              "@id": "_:b523",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test006c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b693",
+                "@id": "_:b524",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b524",
+              "@id": "_:b692",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test006c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b525",
+                "@id": "_:b693",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1066,26 +1075,27 @@
               }
             },
             {
-              "@id": "_:b694",
+              "@id": "_:b525",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test008c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b695",
+                "@id": "_:b526",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b526",
+              "@id": "_:b694",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test008c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b527",
+                "@id": "_:b695",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1147,26 +1157,27 @@
               }
             },
             {
-              "@id": "_:b696",
+              "@id": "_:b527",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test009c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b697",
+                "@id": "_:b528",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b528",
+              "@id": "_:b696",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test009c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b529",
+                "@id": "_:b697",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1228,26 +1239,27 @@
               }
             },
             {
-              "@id": "_:b698",
+              "@id": "_:b529",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test010c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b699",
+                "@id": "_:b530",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b530",
+              "@id": "_:b698",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test010c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b531",
+                "@id": "_:b699",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1309,26 +1321,27 @@
               }
             },
             {
-              "@id": "_:b700",
+              "@id": "_:b531",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test011c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b701",
+                "@id": "_:b532",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b532",
+              "@id": "_:b700",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test011c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b533",
+                "@id": "_:b701",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1390,26 +1403,27 @@
               }
             },
             {
-              "@id": "_:b702",
+              "@id": "_:b533",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test013c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b703",
+                "@id": "_:b534",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b534",
+              "@id": "_:b702",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test013c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b535",
+                "@id": "_:b703",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1471,26 +1485,27 @@
               }
             },
             {
-              "@id": "_:b704",
+              "@id": "_:b535",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test014c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b705",
+                "@id": "_:b536",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b536",
+              "@id": "_:b704",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test014c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b537",
+                "@id": "_:b705",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1552,26 +1567,27 @@
               }
             },
             {
-              "@id": "_:b706",
+              "@id": "_:b537",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b707",
+                "@id": "_:b538",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b538",
+              "@id": "_:b706",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b539",
+                "@id": "_:b707",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1633,26 +1649,27 @@
               }
             },
             {
-              "@id": "_:b708",
+              "@id": "_:b539",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b709",
+                "@id": "_:b540",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b540",
+              "@id": "_:b708",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test016m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b541",
+                "@id": "_:b709",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1714,26 +1731,27 @@
               }
             },
             {
-              "@id": "_:b710",
+              "@id": "_:b541",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b711",
+                "@id": "_:b542",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b542",
+              "@id": "_:b710",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b543",
+                "@id": "_:b711",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1795,26 +1813,27 @@
               }
             },
             {
-              "@id": "_:b712",
+              "@id": "_:b543",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b713",
+                "@id": "_:b544",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b544",
+              "@id": "_:b712",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test017m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b545",
+                "@id": "_:b713",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1876,26 +1895,27 @@
               }
             },
             {
-              "@id": "_:b714",
+              "@id": "_:b545",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b715",
+                "@id": "_:b546",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b546",
+              "@id": "_:b714",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b547",
+                "@id": "_:b715",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -1957,26 +1977,27 @@
               }
             },
             {
-              "@id": "_:b716",
+              "@id": "_:b547",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b717",
+                "@id": "_:b548",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b548",
+              "@id": "_:b716",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test018m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b549",
+                "@id": "_:b717",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2038,26 +2059,27 @@
               }
             },
             {
-              "@id": "_:b718",
+              "@id": "_:b549",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test019c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b719",
+                "@id": "_:b550",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b550",
+              "@id": "_:b718",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test019c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b551",
+                "@id": "_:b719",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2119,26 +2141,27 @@
               }
             },
             {
-              "@id": "_:b720",
+              "@id": "_:b551",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b721",
+                "@id": "_:b552",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b552",
+              "@id": "_:b720",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b553",
+                "@id": "_:b721",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2200,26 +2223,27 @@
               }
             },
             {
-              "@id": "_:b722",
+              "@id": "_:b553",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b723",
+                "@id": "_:b554",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b554",
+              "@id": "_:b722",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test020m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b555",
+                "@id": "_:b723",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2281,26 +2305,27 @@
               }
             },
             {
-              "@id": "_:b724",
+              "@id": "_:b555",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test021c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b725",
+                "@id": "_:b556",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b556",
+              "@id": "_:b724",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test021c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b557",
+                "@id": "_:b725",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2362,26 +2387,27 @@
               }
             },
             {
-              "@id": "_:b726",
+              "@id": "_:b557",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test022c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b727",
+                "@id": "_:b558",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b558",
+              "@id": "_:b726",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test022c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b559",
+                "@id": "_:b727",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2443,26 +2469,27 @@
               }
             },
             {
-              "@id": "_:b728",
+              "@id": "_:b559",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test023c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b729",
+                "@id": "_:b560",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b560",
+              "@id": "_:b728",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test023c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b561",
+                "@id": "_:b729",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2524,26 +2551,27 @@
               }
             },
             {
-              "@id": "_:b730",
+              "@id": "_:b561",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test024c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b731",
+                "@id": "_:b562",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b562",
+              "@id": "_:b730",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test024c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b563",
+                "@id": "_:b731",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2605,26 +2633,27 @@
               }
             },
             {
-              "@id": "_:b732",
+              "@id": "_:b563",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test025c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b733",
+                "@id": "_:b564",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b564",
+              "@id": "_:b732",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test025c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b565",
+                "@id": "_:b733",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2686,26 +2715,27 @@
               }
             },
             {
-              "@id": "_:b734",
+              "@id": "_:b565",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test026c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b735",
+                "@id": "_:b566",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b566",
+              "@id": "_:b734",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test026c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b567",
+                "@id": "_:b735",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2767,26 +2797,27 @@
               }
             },
             {
-              "@id": "_:b736",
+              "@id": "_:b567",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test027c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b737",
+                "@id": "_:b568",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b568",
+              "@id": "_:b736",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test027c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b569",
+                "@id": "_:b737",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2848,26 +2879,27 @@
               }
             },
             {
-              "@id": "_:b738",
+              "@id": "_:b569",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test028c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b739",
+                "@id": "_:b570",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b570",
+              "@id": "_:b738",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test028c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b571",
+                "@id": "_:b739",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -2929,26 +2961,27 @@
               }
             },
             {
-              "@id": "_:b740",
+              "@id": "_:b571",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test029c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b741",
+                "@id": "_:b572",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b572",
+              "@id": "_:b740",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test029c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b573",
+                "@id": "_:b741",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3010,26 +3043,27 @@
               }
             },
             {
-              "@id": "_:b742",
+              "@id": "_:b573",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b743",
+                "@id": "_:b574",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b574",
+              "@id": "_:b742",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b575",
+                "@id": "_:b743",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3091,26 +3125,27 @@
               }
             },
             {
-              "@id": "_:b744",
+              "@id": "_:b575",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b745",
+                "@id": "_:b576",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b576",
+              "@id": "_:b744",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test030m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b577",
+                "@id": "_:b745",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3172,26 +3207,27 @@
               }
             },
             {
-              "@id": "_:b746",
+              "@id": "_:b577",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test033c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b747",
+                "@id": "_:b578",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b578",
+              "@id": "_:b746",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test033c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b579",
+                "@id": "_:b747",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3253,26 +3289,27 @@
               }
             },
             {
-              "@id": "_:b748",
+              "@id": "_:b579",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test034c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b749",
+                "@id": "_:b580",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b580",
+              "@id": "_:b748",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test034c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b581",
+                "@id": "_:b749",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3334,26 +3371,27 @@
               }
             },
             {
-              "@id": "_:b750",
+              "@id": "_:b581",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test035c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b751",
+                "@id": "_:b582",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b582",
+              "@id": "_:b750",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test035c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b583",
+                "@id": "_:b751",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3415,26 +3453,27 @@
               }
             },
             {
-              "@id": "_:b752",
+              "@id": "_:b583",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test036c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b753",
+                "@id": "_:b584",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b584",
+              "@id": "_:b752",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test036c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b585",
+                "@id": "_:b753",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3496,26 +3535,27 @@
               }
             },
             {
-              "@id": "_:b754",
+              "@id": "_:b585",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test038c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b755",
+                "@id": "_:b586",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b586",
+              "@id": "_:b754",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test038c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b587",
+                "@id": "_:b755",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3577,26 +3617,27 @@
               }
             },
             {
-              "@id": "_:b756",
+              "@id": "_:b587",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test039c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b757",
+                "@id": "_:b588",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b588",
+              "@id": "_:b756",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test039c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b589",
+                "@id": "_:b757",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3658,26 +3699,27 @@
               }
             },
             {
-              "@id": "_:b758",
+              "@id": "_:b589",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test040c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b759",
+                "@id": "_:b590",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b590",
+              "@id": "_:b758",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test040c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b591",
+                "@id": "_:b759",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3739,26 +3781,27 @@
               }
             },
             {
-              "@id": "_:b760",
+              "@id": "_:b591",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test043c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b761",
+                "@id": "_:b592",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b592",
+              "@id": "_:b760",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test043c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b593",
+                "@id": "_:b761",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3821,26 +3864,27 @@
               }
             },
             {
-              "@id": "_:b762",
+              "@id": "_:b593",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test044c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b763",
+                "@id": "_:b594",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b594",
+              "@id": "_:b762",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test044c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b595",
+                "@id": "_:b763",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3903,26 +3947,27 @@
               }
             },
             {
-              "@id": "_:b764",
+              "@id": "_:b595",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test045c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b765",
+                "@id": "_:b596",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b596",
+              "@id": "_:b764",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test045c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b597",
+                "@id": "_:b765",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -3985,26 +4030,27 @@
               }
             },
             {
-              "@id": "_:b766",
+              "@id": "_:b597",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test046c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b767",
+                "@id": "_:b598",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b598",
+              "@id": "_:b766",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test046c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b599",
+                "@id": "_:b767",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4066,26 +4112,27 @@
               }
             },
             {
-              "@id": "_:b768",
+              "@id": "_:b599",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b769",
+                "@id": "_:b600",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b600",
+              "@id": "_:b768",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b601",
+                "@id": "_:b769",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4147,26 +4194,27 @@
               }
             },
             {
-              "@id": "_:b770",
+              "@id": "_:b601",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b771",
+                "@id": "_:b602",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b602",
+              "@id": "_:b770",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test047m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b603",
+                "@id": "_:b771",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4228,26 +4276,27 @@
               }
             },
             {
-              "@id": "_:b772",
+              "@id": "_:b603",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b773",
+                "@id": "_:b604",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b604",
+              "@id": "_:b772",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b605",
+                "@id": "_:b773",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4309,26 +4358,27 @@
               }
             },
             {
-              "@id": "_:b774",
+              "@id": "_:b605",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b775",
+                "@id": "_:b606",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b606",
+              "@id": "_:b774",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test048m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b607",
+                "@id": "_:b775",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4391,26 +4441,27 @@
               }
             },
             {
-              "@id": "_:b776",
+              "@id": "_:b607",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b777",
+                "@id": "_:b608",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b608",
+              "@id": "_:b776",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b609",
+                "@id": "_:b777",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4473,26 +4524,27 @@
               }
             },
             {
-              "@id": "_:b778",
+              "@id": "_:b609",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b779",
+                "@id": "_:b610",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b610",
+              "@id": "_:b778",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test053m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b611",
+                "@id": "_:b779",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4554,26 +4606,27 @@
               }
             },
             {
-              "@id": "_:b780",
+              "@id": "_:b611",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test054c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b781",
+                "@id": "_:b612",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b612",
+              "@id": "_:b780",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test054c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b613",
+                "@id": "_:b781",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4635,26 +4688,27 @@
               }
             },
             {
-              "@id": "_:b782",
+              "@id": "_:b613",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b783",
+                "@id": "_:b614",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b614",
+              "@id": "_:b782",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b615",
+                "@id": "_:b783",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4716,26 +4770,27 @@
               }
             },
             {
-              "@id": "_:b784",
+              "@id": "_:b615",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b785",
+                "@id": "_:b616",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b616",
+              "@id": "_:b784",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test055m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b617",
+                "@id": "_:b785",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4797,26 +4852,27 @@
               }
             },
             {
-              "@id": "_:b786",
+              "@id": "_:b617",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b787",
+                "@id": "_:b618",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b618",
+              "@id": "_:b786",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b619",
+                "@id": "_:b787",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4878,26 +4934,27 @@
               }
             },
             {
-              "@id": "_:b788",
+              "@id": "_:b619",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b789",
+                "@id": "_:b620",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b620",
+              "@id": "_:b788",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test056m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b621",
+                "@id": "_:b789",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -4959,26 +5016,27 @@
               }
             },
             {
-              "@id": "_:b790",
+              "@id": "_:b621",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b791",
+                "@id": "_:b622",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b622",
+              "@id": "_:b790",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b623",
+                "@id": "_:b791",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -5040,26 +5098,27 @@
               }
             },
             {
-              "@id": "_:b792",
+              "@id": "_:b623",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b793",
+                "@id": "_:b624",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b624",
+              "@id": "_:b792",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test057m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b625",
+                "@id": "_:b793",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -5121,26 +5180,27 @@
               }
             },
             {
-              "@id": "_:b794",
+              "@id": "_:b625",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test058c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b795",
+                "@id": "_:b626",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b626",
+              "@id": "_:b794",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test058c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b627",
+                "@id": "_:b795",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -5202,26 +5262,27 @@
               }
             },
             {
-              "@id": "_:b796",
+              "@id": "_:b627",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test059c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b797",
+                "@id": "_:b628",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b628",
+              "@id": "_:b796",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test059c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b629",
+                "@id": "_:b797",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -5283,26 +5344,27 @@
               }
             },
             {
-              "@id": "_:b798",
+              "@id": "_:b629",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b799",
+                "@id": "_:b630",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b630",
+              "@id": "_:b798",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b631",
+                "@id": "_:b799",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -5364,26 +5426,27 @@
               }
             },
             {
-              "@id": "_:b800",
+              "@id": "_:b631",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b801",
+                "@id": "_:b632",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b632",
+              "@id": "_:b800",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test060m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b633",
+                "@id": "_:b801",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -5445,26 +5508,27 @@
               }
             },
             {
-              "@id": "_:b802",
+              "@id": "_:b633",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test061c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b803",
+                "@id": "_:b634",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b634",
+              "@id": "_:b802",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test061c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b635",
+                "@id": "_:b803",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -5526,26 +5590,27 @@
               }
             },
             {
-              "@id": "_:b804",
+              "@id": "_:b635",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test062c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b805",
+                "@id": "_:b636",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b636",
+              "@id": "_:b804",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test062c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b637",
+                "@id": "_:b805",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -5608,26 +5673,27 @@
               }
             },
             {
-              "@id": "_:b806",
+              "@id": "_:b637",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b807",
+                "@id": "_:b638",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b638",
+              "@id": "_:b806",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b639",
+                "@id": "_:b807",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -5690,26 +5756,27 @@
               }
             },
             {
-              "@id": "_:b808",
+              "@id": "_:b639",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b809",
+                "@id": "_:b640",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b640",
+              "@id": "_:b808",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test063m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b641",
+                "@id": "_:b809",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -5771,26 +5838,27 @@
               }
             },
             {
-              "@id": "_:b810",
+              "@id": "_:b641",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test064c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b811",
+                "@id": "_:b642",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b642",
+              "@id": "_:b810",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test064c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b643",
+                "@id": "_:b811",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -5852,26 +5920,27 @@
               }
             },
             {
-              "@id": "_:b812",
+              "@id": "_:b643",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test065c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b813",
+                "@id": "_:b644",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b644",
+              "@id": "_:b812",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test065c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b645",
+                "@id": "_:b813",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -5933,26 +6002,27 @@
               }
             },
             {
-              "@id": "_:b814",
+              "@id": "_:b645",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test066c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b815",
+                "@id": "_:b646",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b646",
+              "@id": "_:b814",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test066c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b647",
+                "@id": "_:b815",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -6014,26 +6084,27 @@
               }
             },
             {
-              "@id": "_:b816",
+              "@id": "_:b647",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test067c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b817",
+                "@id": "_:b648",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b648",
+              "@id": "_:b816",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test067c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b649",
+                "@id": "_:b817",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -6095,26 +6166,27 @@
               }
             },
             {
-              "@id": "_:b818",
+              "@id": "_:b649",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test068c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b819",
+                "@id": "_:b650",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b650",
+              "@id": "_:b818",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test068c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b651",
+                "@id": "_:b819",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -6176,26 +6248,27 @@
               }
             },
             {
-              "@id": "_:b820",
+              "@id": "_:b651",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test069c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b821",
+                "@id": "_:b652",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b652",
+              "@id": "_:b820",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test069c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b653",
+                "@id": "_:b821",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -6258,26 +6331,27 @@
               }
             },
             {
-              "@id": "_:b822",
+              "@id": "_:b653",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test070c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b823",
+                "@id": "_:b654",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b654",
+              "@id": "_:b822",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test070c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b655",
+                "@id": "_:b823",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -6340,26 +6414,27 @@
               }
             },
             {
-              "@id": "_:b824",
+              "@id": "_:b655",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test070m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b825",
+                "@id": "_:b656",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b656",
+              "@id": "_:b824",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test070m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b657",
+                "@id": "_:b825",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -6422,26 +6497,27 @@
               }
             },
             {
-              "@id": "_:b826",
+              "@id": "_:b657",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test071c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b827",
+                "@id": "_:b658",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b658",
+              "@id": "_:b826",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test071c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b659",
+                "@id": "_:b827",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -6504,26 +6580,27 @@
               }
             },
             {
-              "@id": "_:b828",
+              "@id": "_:b659",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test071m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b829",
+                "@id": "_:b660",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b660",
+              "@id": "_:b828",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test071m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b661",
+                "@id": "_:b829",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -6586,26 +6663,27 @@
               }
             },
             {
-              "@id": "_:b830",
+              "@id": "_:b661",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test072c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b831",
+                "@id": "_:b662",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b662",
+              "@id": "_:b830",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test072c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b663",
+                "@id": "_:b831",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -6668,26 +6746,27 @@
               }
             },
             {
-              "@id": "_:b832",
+              "@id": "_:b663",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test072m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b833",
+                "@id": "_:b664",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b664",
+              "@id": "_:b832",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test072m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b665",
+                "@id": "_:b833",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -6750,26 +6829,27 @@
               }
             },
             {
-              "@id": "_:b834",
+              "@id": "_:b665",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test073c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b835",
+                "@id": "_:b666",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b666",
+              "@id": "_:b834",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test073c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b667",
+                "@id": "_:b835",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -6832,26 +6912,27 @@
               }
             },
             {
-              "@id": "_:b836",
+              "@id": "_:b667",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test073m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b837",
+                "@id": "_:b668",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b668",
+              "@id": "_:b836",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test073m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b669",
+                "@id": "_:b837",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -6913,26 +6994,27 @@
               }
             },
             {
-              "@id": "_:b838",
+              "@id": "_:b669",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test074c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b839",
+                "@id": "_:b670",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b670",
+              "@id": "_:b838",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test074c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b671",
+                "@id": "_:b839",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -6996,26 +7078,27 @@
               }
             },
             {
-              "@id": "_:b840",
+              "@id": "_:b671",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075c",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b841",
+                "@id": "_:b672",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b672",
+              "@id": "_:b840",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075c",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b673",
+                "@id": "_:b841",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
@@ -7066,65 +7149,66 @@
           "testResult": "https://w3c.github.io/rdf-canon/tests/rdfc10/test075-rdfc10map.json",
           "assertions": [
             {
-              "@id": "_:b167",
+              "@id": "_:b1",
               "@type": "Assertion",
               "subject": "https://github.com/digitalbazaar/rdf-canonize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075m",
               "assertedBy": "https://digitalbazaar.com/",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b168",
+                "@id": "_:b2",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b842",
+              "@id": "_:b507",
               "@type": "Assertion",
               "subject": "https://github.com/pchampin/sophia_rs",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075m",
+              "assertedBy": "http://champin.net/#pa",
+              "mode": "earl:automatic",
               "result": {
-                "@id": "_:b843",
+                "@id": "_:b508",
                 "@type": "TestResult",
-                "outcome": "earl:untested"
-              },
-              "assertedBy": null
+                "outcome": "earl:passed"
+              }
             },
             {
-              "@id": "_:b674",
+              "@id": "_:b676",
               "@type": "Assertion",
               "subject": "https://github.com/zkp-ld/rdf-canon",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075m",
               "assertedBy": "https://github.com/yamdan",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b675",
+                "@id": "_:b677",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b336",
+              "@id": "_:b170",
               "@type": "Assertion",
               "subject": "https://iherman.github.io/rdfjs-c14n/",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075m",
               "assertedBy": "https://www.ivan-herman.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b337",
+                "@id": "_:b171",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }
             },
             {
-              "@id": "_:b505",
+              "@id": "_:b339",
               "@type": "Assertion",
               "subject": "https://rubygems.org/gems/rdf-normalize",
               "test": "https://w3c.github.io/rdf-canon/tests/manifest#test075m",
               "assertedBy": "https://greggkellogg.net/foaf#me",
               "mode": "earl:automatic",
               "result": {
-                "@id": "_:b506",
+                "@id": "_:b340",
                 "@type": "TestResult",
                 "outcome": "earl:passed"
               }

--- a/reports/earl.ttl
+++ b/reports/earl.ttl
@@ -133,8 +133,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test001c> ;
@@ -185,8 +186,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test002c> ;
@@ -237,8 +239,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test003c> ;
@@ -289,8 +292,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test003m> ;
@@ -341,8 +345,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test004c> ;
@@ -393,8 +398,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test004m> ;
@@ -445,8 +451,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test005c> ;
@@ -497,8 +504,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test005m> ;
@@ -549,8 +557,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test006c> ;
@@ -601,8 +610,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test008c> ;
@@ -653,8 +663,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test009c> ;
@@ -705,8 +716,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test010c> ;
@@ -757,8 +769,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test011c> ;
@@ -809,8 +822,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test013c> ;
@@ -861,8 +875,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test014c> ;
@@ -913,8 +928,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test016c> ;
@@ -965,8 +981,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test016m> ;
@@ -1017,8 +1034,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test017c> ;
@@ -1069,8 +1087,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test017m> ;
@@ -1121,8 +1140,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test018c> ;
@@ -1173,8 +1193,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test018m> ;
@@ -1225,8 +1246,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test019c> ;
@@ -1277,8 +1299,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test020c> ;
@@ -1329,8 +1352,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test020m> ;
@@ -1381,8 +1405,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test021c> ;
@@ -1433,8 +1458,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test022c> ;
@@ -1485,8 +1511,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test023c> ;
@@ -1537,8 +1564,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test024c> ;
@@ -1589,8 +1617,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test025c> ;
@@ -1641,8 +1670,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test026c> ;
@@ -1693,8 +1723,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test027c> ;
@@ -1745,8 +1776,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test028c> ;
@@ -1797,8 +1829,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test029c> ;
@@ -1849,8 +1882,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test030c> ;
@@ -1901,8 +1935,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test030m> ;
@@ -1953,8 +1988,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test033c> ;
@@ -2005,8 +2041,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test034c> ;
@@ -2057,8 +2094,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test035c> ;
@@ -2109,8 +2147,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test036c> ;
@@ -2161,8 +2200,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test038c> ;
@@ -2213,8 +2253,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test039c> ;
@@ -2265,8 +2306,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test040c> ;
@@ -2317,8 +2359,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test043c> ;
@@ -2370,8 +2413,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test044c> ;
@@ -2423,8 +2467,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test045c> ;
@@ -2476,8 +2521,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test046c> ;
@@ -2528,8 +2574,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test047c> ;
@@ -2580,8 +2627,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test047m> ;
@@ -2632,8 +2680,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test048c> ;
@@ -2684,8 +2733,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test048m> ;
@@ -2737,8 +2787,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test053c> ;
@@ -2790,8 +2841,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test053m> ;
@@ -2842,8 +2894,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test054c> ;
@@ -2894,8 +2947,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test055c> ;
@@ -2946,8 +3000,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test055m> ;
@@ -2998,8 +3053,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test056c> ;
@@ -3050,8 +3106,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test056m> ;
@@ -3102,8 +3159,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test057c> ;
@@ -3154,8 +3212,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test057m> ;
@@ -3206,8 +3265,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test058c> ;
@@ -3258,8 +3318,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test059c> ;
@@ -3310,8 +3371,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test060c> ;
@@ -3362,8 +3424,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test060m> ;
@@ -3414,8 +3477,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test061c> ;
@@ -3466,8 +3530,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test062c> ;
@@ -3519,8 +3584,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test063c> ;
@@ -3572,8 +3638,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test063m> ;
@@ -3624,8 +3691,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test064c> ;
@@ -3676,8 +3744,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test065c> ;
@@ -3728,8 +3797,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test066c> ;
@@ -3780,8 +3850,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test067c> ;
@@ -3832,8 +3903,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test068c> ;
@@ -3884,8 +3956,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test069c> ;
@@ -3937,8 +4010,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test070c> ;
@@ -3990,8 +4064,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test070m> ;
@@ -4043,8 +4118,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test071c> ;
@@ -4096,8 +4172,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test071m> ;
@@ -4149,8 +4226,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test072c> ;
@@ -4202,8 +4280,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test072m> ;
@@ -4255,8 +4334,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test073c> ;
@@ -4308,8 +4388,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test073m> ;
@@ -4360,8 +4441,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test074c> ;
@@ -4414,8 +4496,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test075c> ;
@@ -4468,8 +4551,9 @@
     earl:subject <https://github.com/pchampin/sophia_rs> ;
     earl:result [
       a earl:TestResult ;
-      earl:outcome earl:untested
+      earl:outcome earl:passed
     ] ;
+    earl:assertedBy <http://champin.net/#pa> ;
   ], [
     a earl:Assertion ;
     earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test075m> ;

--- a/reports/earl.ttl
+++ b/reports/earl.ttl
@@ -4655,5 +4655,5 @@
 
 <https://github.com/gkellogg/earl-report/tree/0.9.0> a doap:Version;
   doap:name "earl-report-0.9.0";
-  doap:created "2023-11-23"^^xsd:date;
+  doap:created "2023-11-28"^^xsd:date;
   doap:revision "0.9.0" .

--- a/reports/index.html
+++ b/reports/index.html
@@ -94,8 +94,8 @@
         EARL results from the RDF Dataset Canonicalization and Hash 1.0 Test Suite
       </h2>
       <h2 id='w3c-document-28-october-2015'>
-        <time class='dt-published' datetime='2023-11-23' property='dc:issued'>
-          23 November 2023
+        <time class='dt-published' datetime='2023-11-28' property='dc:issued'>
+          28 November 2023
         </time>
       </h2>
       <dl>
@@ -343,6 +343,13 @@
               </a>
             </th>
             <th>
+              <a href='#subj_Sophia_Rust'>
+                Sophia
+                <br />
+                (Rust)
+              </a>
+            </th>
+            <th>
               <a href='#subj_zkp_ld_rdf_canon_Rust'>
                 zkp-ld/rdf-canon
                 <br />
@@ -380,10 +387,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test002c'>Test test002c: duplicate property iri values</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -414,10 +427,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test003m'>Test test003m: bnode (map test)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -448,10 +467,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test004m'>Test test004m: bnode plus embed w/subject (map test)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -482,10 +507,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test005m'>Test test005m: bnode embed (map test)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -516,10 +547,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test008c'>Test test008c: single subject complex</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -550,10 +587,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test010c'>Test test010c: type</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -584,10 +627,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test013c'>Test test013c: type-coerced type, cycle</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -618,10 +667,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test016c'>Test test016c: blank node - dual link - embed</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -652,10 +707,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test017c'>Test test017c: blank node - dual link - non-embed</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -686,10 +747,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test018c'>Test test018c: blank node - self link</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -720,10 +787,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test019c'>Test test019c: blank node - disjoint self links</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -754,10 +827,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test020m'>Test test020m: blank node - diamond (map test)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -788,10 +867,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test022c'>Test test022c: blank node - double circle of 2</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -822,10 +907,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test024c'>Test test024c: blank node - double circle of 3 (0-1-2)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -856,10 +947,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test026c'>Test test026c: blank node - double circle of 3 (1-0-2)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -890,10 +987,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test028c'>Test test028c: blank node - double circle of 3 (2-1-0)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -924,10 +1027,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test030c'>Test test030c: blank node - point at circle of 3</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -958,10 +1067,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test033c'>Test test033c: disjoint identical subgraphs (1)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -992,10 +1107,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test035c'>Test test035c: reordered w/strings (1)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1026,10 +1147,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test038c'>Test test038c: reordered 4 bnodes, reordered 2 properties (1)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1060,10 +1187,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test040c'>Test test040c: reordered 6 bnodes (1)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1094,10 +1227,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test044c'>Test test044c: poison – evil (1)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1128,10 +1267,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test046c'>Test test046c: poison – evil (3)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1162,10 +1307,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test047m'>Test test047m: deep diff (1) (map test)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1196,10 +1347,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test048m'>Test test048m: deep diff (2) (map test)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1230,10 +1387,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test053m'>Test test053m: @list (map test)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1264,10 +1427,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test055c'>Test test055c: simple reorder (1)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1298,10 +1467,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test056c'>Test test056c: simple reorder (2)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1332,10 +1507,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test057c'>Test test057c: unnamed graph</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1366,10 +1547,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test058c'>Test test058c: unnamed graph with blank node objects</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1400,10 +1587,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test060c'>Test test060c: n-quads escaping</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1434,10 +1627,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test061c'>Test test061c: same literal value with multiple languages</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1468,10 +1667,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test063c'>Test test063c: blank node - diamond (with _:b)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1502,10 +1707,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test064c'>Test test064c: blank node - double circle of 3 (0-1-2, reversed)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1536,10 +1747,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test066c'>Test test066c: blank node - double circle of 3 (1-0-2, reversed)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1570,10 +1787,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test068c'>Test test068c: blank node - double circle of 3 (2-1-0, reversed)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1604,10 +1827,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test070c'>Test test070c: dataset - isomorphic default and iri named</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1638,10 +1867,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test071c'>Test test071c: dataset - isomorphic default and node named</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1672,10 +1907,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test072c'>Test test072c: dataset - shared blank nodes</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1706,10 +1947,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test073c'>Test test073c: dataset - referencing graph name</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1740,10 +1987,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
               <a href='https://w3c.github.io/rdf-canon/tests/manifest#test074c'>Test test074c: poison - Clique Graph (negative test)</a>
+            </td>
+            <td class='PASS'>
+              PASS
             </td>
             <td class='PASS'>
               PASS
@@ -1774,6 +2027,9 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='normative'>
             <td>
@@ -1791,10 +2047,16 @@
             <td class='PASS'>
               PASS
             </td>
+            <td class='PASS'>
+              PASS
+            </td>
           </tr>
           <tr class='summary'>
             <td>
               Percentage passed out of 84 Tests
+            </td>
+            <td class='passed-all'>
+              100.0%
             </td>
             <td class='passed-all'>
               100.0%
@@ -1905,6 +2167,14 @@
             <dd>
               <table class='report'>
                 <tbody>
+                  <tr>
+                    <td>
+                      RDF Dataset Canonicalization (RDFC-1.0) Test Suite
+                    </td>
+                    <td class='passed-all'>
+                      84/84 (100.0%)
+                    </td>
+                  </tr>
                 </tbody>
               </table>
             </dd>

--- a/reports/rust-sophia-rdfc10.ttl
+++ b/reports/rust-sophia-rdfc10.ttl
@@ -1,6 +1,6 @@
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-PREFIX earl: <https://www.w3.org/ns/earl#>
+PREFIX earl: <http://www.w3.org/ns/earl#>
 
 <>
   dct:issued "2023-09-15T16:58:44.930088350+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
@@ -14,7 +14,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.893243416+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "simple id";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test001c>.
 
 [] a earl:Assertion;
@@ -24,7 +24,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.893425254+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "duplicate property iri values";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test002c>.
 
 [] a earl:Assertion;
@@ -34,7 +34,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.893610798+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "bnode";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test003c>.
 
 [] a earl:Assertion;
@@ -44,7 +44,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.893784627+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "bnode (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test003m>.
 
 [] a earl:Assertion;
@@ -54,7 +54,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.893959967+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "bnode plus embed w/subject";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test004c>.
 
 [] a earl:Assertion;
@@ -64,7 +64,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.894132753+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "bnode plus embed w/subject (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test004m>.
 
 [] a earl:Assertion;
@@ -74,7 +74,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.894316344+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "bnode embed";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test005c>.
 
 [] a earl:Assertion;
@@ -84,7 +84,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.894491262+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "bnode embed (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test005m>.
 
 [] a earl:Assertion;
@@ -94,7 +94,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.894668235+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "multiple rdf types";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test006c>.
 
 [] a earl:Assertion;
@@ -104,7 +104,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.894852231+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "single subject complex";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test008c>.
 
 [] a earl:Assertion;
@@ -114,7 +114,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.895040844+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "multiple subjects - complex";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test009c>.
 
 [] a earl:Assertion;
@@ -124,7 +124,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.895211765+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "type";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test010c>.
 
 [] a earl:Assertion;
@@ -134,7 +134,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.895380753+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "type-coerced type";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test011c>.
 
 [] a earl:Assertion;
@@ -144,7 +144,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.895554745+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "type-coerced type, cycle";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test013c>.
 
 [] a earl:Assertion;
@@ -154,7 +154,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.895729383+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "check types";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test014c>.
 
 [] a earl:Assertion;
@@ -164,7 +164,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.895905396+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - dual link - embed";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test016c>.
 
 [] a earl:Assertion;
@@ -174,7 +174,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.896079728+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - dual link - embed (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test016m>.
 
 [] a earl:Assertion;
@@ -184,7 +184,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.896253035+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - dual link - non-embed";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test017c>.
 
 [] a earl:Assertion;
@@ -194,7 +194,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.896423238+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - dual link - non-embed (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test017m>.
 
 [] a earl:Assertion;
@@ -204,7 +204,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.896600007+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - self link";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test018c>.
 
 [] a earl:Assertion;
@@ -214,7 +214,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.896768321+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - self link (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test018m>.
 
 [] a earl:Assertion;
@@ -224,7 +224,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.896947718+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - disjoint self links";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test019c>.
 
 [] a earl:Assertion;
@@ -234,7 +234,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.897128054+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - diamond";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test020c>.
 
 [] a earl:Assertion;
@@ -244,7 +244,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.897307512+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - diamond (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test020m>.
 
 [] a earl:Assertion;
@@ -254,7 +254,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.897514679+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - circle of 2";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test021c>.
 
 [] a earl:Assertion;
@@ -264,7 +264,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.897741585+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - double circle of 2";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test022c>.
 
 [] a earl:Assertion;
@@ -274,7 +274,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.897982944+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - circle of 3";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test023c>.
 
 [] a earl:Assertion;
@@ -284,7 +284,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.898274490+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - double circle of 3 (0-1-2)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test024c>.
 
 [] a earl:Assertion;
@@ -294,7 +294,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.898564544+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - double circle of 3 (0-2-1)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test025c>.
 
 [] a earl:Assertion;
@@ -304,7 +304,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.898856282+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - double circle of 3 (1-0-2)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test026c>.
 
 [] a earl:Assertion;
@@ -314,7 +314,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.899148626+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - double circle of 3 (1-2-0)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test027c>.
 
 [] a earl:Assertion;
@@ -324,7 +324,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.899438417+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - double circle of 3 (2-1-0)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test028c>.
 
 [] a earl:Assertion;
@@ -334,7 +334,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.899727699+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - double circle of 3 (2-0-1)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test029c>.
 
 [] a earl:Assertion;
@@ -344,7 +344,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.899915569+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - point at circle of 3";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test030c>.
 
 [] a earl:Assertion;
@@ -354,7 +354,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.900099136+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - point at circle of 3 (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test030m>.
 
 [] a earl:Assertion;
@@ -364,7 +364,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.900299393+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "disjoint identical subgraphs (1)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test033c>.
 
 [] a earl:Assertion;
@@ -374,7 +374,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.900543848+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "disjoint identical subgraphs (2)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test034c>.
 
 [] a earl:Assertion;
@@ -384,7 +384,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.900750297+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "reordered w/strings (1)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test035c>.
 
 [] a earl:Assertion;
@@ -394,7 +394,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.900953598+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "reordered w/strings (2)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test036c>.
 
 [] a earl:Assertion;
@@ -404,7 +404,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.901137486+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "reordered 4 bnodes, reordered 2 properties (1)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test038c>.
 
 [] a earl:Assertion;
@@ -414,7 +414,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.901320629+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "reordered 4 bnodes, reordered 2 properties (2)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test039c>.
 
 [] a earl:Assertion;
@@ -424,7 +424,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.901549708+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "reordered 6 bnodes (1)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test040c>.
 
 [] a earl:Assertion;
@@ -434,7 +434,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.901762774+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "literal with language";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test043c>.
 
 [] a earl:Assertion;
@@ -444,7 +444,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.908591536+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "poison – evil (1)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test044c>.
 
 [] a earl:Assertion;
@@ -454,7 +454,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.915505601+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "poison – evil (2)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test045c>.
 
 [] a earl:Assertion;
@@ -464,7 +464,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.922023115+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "poison – evil (3)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test046c>.
 
 [] a earl:Assertion;
@@ -474,7 +474,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.922258641+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "deep diff (1)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test047c>.
 
 [] a earl:Assertion;
@@ -484,7 +484,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.922470425+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "deep diff (1) (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test047m>.
 
 [] a earl:Assertion;
@@ -494,7 +494,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.922680586+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "deep diff (2)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test048c>.
 
 [] a earl:Assertion;
@@ -504,7 +504,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.922887577+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "deep diff (2) (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test048m>.
 
 [] a earl:Assertion;
@@ -514,7 +514,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.923098424+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "@list";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test053c>.
 
 [] a earl:Assertion;
@@ -524,7 +524,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.923298651+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "@list (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test053m>.
 
 [] a earl:Assertion;
@@ -534,7 +534,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.923660387+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "t-graph";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test054c>.
 
 [] a earl:Assertion;
@@ -544,7 +544,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.923825513+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "simple reorder (1)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test055c>.
 
 [] a earl:Assertion;
@@ -554,7 +554,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.923985937+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "simple reorder (1) (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test055m>.
 
 [] a earl:Assertion;
@@ -564,7 +564,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.924148808+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "simple reorder (2)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test056c>.
 
 [] a earl:Assertion;
@@ -574,7 +574,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.924308485+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "simple reorder (2) (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test056m>.
 
 [] a earl:Assertion;
@@ -584,7 +584,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.924488536+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "unnamed graph";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test057c>.
 
 [] a earl:Assertion;
@@ -594,7 +594,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.924652661+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "unnamed graph (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test057m>.
 
 [] a earl:Assertion;
@@ -604,7 +604,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.924824154+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "unnamed graph with blank node objects";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test058c>.
 
 [] a earl:Assertion;
@@ -614,7 +614,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.925181719+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "n-quads parsing";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test059c>.
 
 [] a earl:Assertion;
@@ -624,7 +624,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.925417739+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "n-quads escaping";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test060c>.
 
 [] a earl:Assertion;
@@ -634,7 +634,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.925661957+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "n-quads escaping (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test060m>.
 
 [] a earl:Assertion;
@@ -644,7 +644,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.925822439+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "same literal value with multiple languages";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test061c>.
 
 [] a earl:Assertion;
@@ -654,7 +654,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.925979589+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "same literal value with multiple datatypes";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test062c>.
 
 [] a earl:Assertion;
@@ -664,7 +664,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.926148462+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - diamond (with _:b)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test063c>.
 
 [] a earl:Assertion;
@@ -674,7 +674,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.926313439+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - diamond (with _:b) (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test063m>.
 
 [] a earl:Assertion;
@@ -684,7 +684,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.926585175+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - double circle of 3 (0-1-2, reversed)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test064c>.
 
 [] a earl:Assertion;
@@ -694,7 +694,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.926853567+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - double circle of 3 (0-2-1, reversed)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test065c>.
 
 [] a earl:Assertion;
@@ -704,7 +704,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.927122294+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - double circle of 3 (1-0-2, reversed)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test066c>.
 
 [] a earl:Assertion;
@@ -714,7 +714,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.927389601+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - double circle of 3 (1-2-0, reversed)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test067c>.
 
 [] a earl:Assertion;
@@ -724,7 +724,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.927656704+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - double circle of 3 (2-1-0, reversed)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test068c>.
 
 [] a earl:Assertion;
@@ -734,7 +734,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.927922251+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - double circle of 3 (2-0-1, reversed)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test069c>.
 
 [] a earl:Assertion;
@@ -744,7 +744,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.928095280+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "dataset - isomorphic default and iri named";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test070c>.
 
 [] a earl:Assertion;
@@ -754,7 +754,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.928265411+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "dataset - isomorphic default and iri named (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test070m>.
 
 [] a earl:Assertion;
@@ -764,7 +764,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.928440225+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "dataset - isomorphic default and node named";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test071c>.
 
 [] a earl:Assertion;
@@ -774,7 +774,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.928620069+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "dataset - isomorphic default and node named (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test071m>.
 
 [] a earl:Assertion;
@@ -784,7 +784,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.928791339+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "dataset - shared blank nodes";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test072c>.
 
 [] a earl:Assertion;
@@ -794,7 +794,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.928960951+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "dataset - shared blank nodes (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test072m>.
 
 [] a earl:Assertion;
@@ -804,7 +804,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.929158061+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "dataset - referencing graph name";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test073c>.
 
 [] a earl:Assertion;
@@ -814,7 +814,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.929356905+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "dataset - referencing graph name (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test073m>.
 
 [] a earl:Assertion;
@@ -824,7 +824,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.929668338+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "poison - Clique Graph (negative test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test074c>.
 
 [] a earl:Assertion;
@@ -834,7 +834,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.929850975+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - diamond (uses SHA-384)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test075c>.
 
 [] a earl:Assertion;
@@ -844,7 +844,7 @@ PREFIX earl: <https://www.w3.org/ns/earl#>
       dct:date "2023-09-15T16:58:44.930017316+00:00"^^<http://www.w3.org/2001/XMLSchema#datetime>;
       dct:title "blank node - diamond (uses SHA-384) (map test)";
       earl:outcome earl:passed];
-  earl:subject <https://crates.io/crates/sophia/0.8.0-alpha.2>;
+  earl:subject <https://github.com/pchampin/sophia_rs>;
   earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test075m>.
 
 # manually added:


### PR DESCRIPTION
… to use the Project IRI rather than the Release IRI in assertions and use the proper prefix for the EARL vocabulary.

Fixes #185.