### PR TITLE
Add "updateable-rec" class to SOTD.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -138,7 +138,7 @@
     performed.</p>
 </section>
 
-<section id="sotd">
+<section id="sotd" class="updateable-rec">
   <p>This document describes the <a>RDFC-1.0</a> algorithm for canonicalizing
     RDF datasets, which was the input from the
     <a href="https://www.w3.org/community/credentials/">W3C Credentials Community Group</a>


### PR DESCRIPTION
This marks adds "Future updates to this Recommendation may incorporate new features.", Where, "new features" is a link to the process document: https://www.w3.org/2023/Process-20231103/#allow-new-features.

For a recommendation to be updatable, it MUST include this reference, The SODT template doesn't really allow changing the wording of this paragraph.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/198.html" title="Last updated on Feb 28, 2024, 6:10 PM UTC (0d5a223)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/198/9cf1297...0d5a223.html" title="Last updated on Feb 28, 2024, 6:10 PM UTC (0d5a223)">Diff</a>