### PR TITLE
Pruning the prior art references

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -3802,56 +3802,6 @@
 
   <ul>
     <li>
-      Corneil, D.G., Gotlieb, C.C.:
-      An Efficient Algorithm for Graph Isomorphism.
-      J. ACM. 17, 51–64 (1970).
-      <a href="https://doi.org/10.1145/321556.321562">https://doi.org/10.1145/321556.321562</a>.
-    </li>
-    <li>
-      Weisfeiler, B.:
-      On Construction and Identification of Graphs.
-      Springer, Berlin, Heidelberg (1976).
-      <a href="https://doi.org/10.1007/BFb0089374">https://doi.org/10.1007/BFb0089374</a>.
-    </li>
-    <li>
-      Babai, L., Erdős, P., Selkow, S.M.:
-      Random Graph Isomorphism.
-      SIAM J. Comput. 9, 628–635 (1980).
-      <a href="https://doi.org/10.1137/0209047">https://doi.org/10.1137/0209047</a>.
-    </li>
-    <li>
-      Hoffmann, C.M. ed:
-      Group-Theoretic Algorithms and Graph Isomorphism.
-      Springer, Berlin, Heidelberg (1982).
-      <a href="https://doi.org/10.1007/3-540-11493-9">https://doi.org/10.1007/3-540-11493-9</a>.
-    </li>
-    <li>
-      Corneil, D., Goldberg, M.:
-      A non-factorial algorithm for canonical numbering of a graph.
-      Journal of Algorithms. 5, 345–362 (1984).
-      <a href="https://doi.org/10.1016/0196-6774(84)90015-4">https://doi.org/10.1016/0196-6774(84)90015-4</a>.
-    </li>
-    <li>
-      Sutcliffe, G., Suttner, C.:
-      The TPTP Problem Library.
-      Journal of Automated Reasoning. 21, 177–203 (1998).
-      <a href="https://doi.org/10.1023/A:1005806324129">https://doi.org/10.1023/A:1005806324129</a>.
-    </li>
-    <li>
-      Grohe, M.:
-      Isomorphism testing for embeddable graphs through definability.
-      In: Proceedings of the thirty-second annual ACM symposium on Theory of computing. pp. 63–72.
-      ACM, Portland Oregon USA (2000).
-      <a href="https://doi.org/10.1145/335305.335313">https://doi.org/10.1145/335305.335313</a>.
-    </li>
-    <li>
-      Tsang, W.W., Hui, L.C.K., Chow, K.P., Chong, C.:
-      Tuning the collision test for stringency,
-      Tech. Rep. TR-2000-05, Computer Science and Information Systems,
-      Hong Kong University (2000).
-      <a href="https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=b9b3c7e4afd78e64c075f90694f0e6021960b3b1">https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=b9b3c7e4afd78e64c075f90694f0e6021960b3b1</a>
-    </li>
-    <li>
       Berners-Lee, T., Connolly, D.:
       [[[DesignIssues-Diff]]]
       W3C Unofficial (2001).
@@ -3899,11 +3849,6 @@
       <a href="https://doi.org/10.1016/j.jcss.2010.01.003">https://doi.org/10.1016/j.jcss.2010.01.003</a>.
     </li>
     <li>
-      Gross, J.L., Yellen, J., Zhang, P.:
-      Handbook of Graph Theory, Second Edition.
-      Chapman & Hall/CRC (2013).
-    </li>
-    <li>
       Kasten, A., Scherp, A., Schauß, P.:
       [[[eswc2014Kasten]]].
       In: Presutti, V., d’Amato, C., Gandon, F., d’Aquin, M., Staab, S., and Tordai, A. (eds.)
@@ -3922,13 +3867,6 @@
       RDF Dataset Normalization.
       Report submitted to the W3C Credentials Community Group mailing list (2020).
       <a href="https://lists.w3.org/Archives/Public/public-credentials/2021Mar/att-0220/RDFDatasetCanonicalization-2020-10-09.pdf">https://lists.w3.org/Archives/Public/public-credentials/2021Mar/att-0220/RDFDatasetCanonicalization-2020-10-09.pdf</a>.
-    </li>
-    <li>
-      Tomaszuk, D., Głąb, S., Turoboś, F., Pawlik, T., Kuziński, D., Sopek, M.:
-      Interwoven Hash of Vicious Circle Free Graph.
-      In: 2022 IEEE International Conference on Blockchain (Blockchain). pp. 449–454. IEEE,
-      Espoo, Finland (2022).
-      <a href="https://doi.org/10.1109/Blockchain55522.2022.00069">https://doi.org/10.1109/Blockchain55522.2022.00069</a>.
     </li>
   </ul>
 </section>


### PR DESCRIPTION
(As agreed in https://github.com/w3c/rdf-canon/pull/199#issuecomment-1973415321, creating this as a separate PR after the merge of #199.)

As argued in https://github.com/w3c/rdf-canon/pull/199#pullrequestreview-1910510063, I believe it is unnecessary to bring in non-RDF references. It is not meaningful for our readers, and it looks like an arbitrary choice from the _huge_ literature on graph theory in general.

(I understand that some of these references may have been relevant for some of the cited works, i.e., they may be, sort of, "second level" references. But the only goal of this section is to show that the spec relies on a bunch of works that have been done in the RDF community. It is not the place to go beyond that imho.)