### PR TITLE
add errata page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Editorial changes that improve the readability of the spec or correct spelling o
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md), about licensing contributions.
 
+## Errata
+
+ * [Errata on the spec](https://w3c.github.io/rdf-canon/errata/)
+ * [Submit an erratum](https://github.com/w3c/rdf-canon/issues/new)
+
 ## Test Suite and Reports
 
 * [Test Suite](https://w3c.github.io/rdf-canon/tests/)

--- a/errata/index.html
+++ b/errata/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <!--
-    The data-githubrepo attribute provides the owner/repo name on github. For W3C repositories most of those are of the
+    The `data-githubrepo` attribute provides the owner/repo name on github. For W3C repositories, most of those are of the
     form 'w3c/XXX', although there are groups that have their own owner for their repository.
   -->
   <head data-githubrepo="w3c/rdf-canon">

--- a/errata/index.html
+++ b/errata/index.html
@@ -6,7 +6,7 @@
   -->
   <head data-githubrepo="w3c/rdf-canon">
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-    <title>Open Errata for the RDF-CANON specification published by the RCH Working Group</title>
+    <title>Open Errata for the "RDF Dataset Canonicalization" (RDF-CANON) specification published by the RCH Working Group</title>
     <link rel="stylesheet" type="text/css" href="errata.css"/>
     <script src="https://w3c.github.io/display_errata/assets/errata.js" type="text/javascript"></script>
     <script src="https://w3c.github.io/display_errata/assets/toc.js" type="text/javascript"></script>
@@ -21,7 +21,7 @@
     <header>
       <p class="banner"><a accesskey="W" href="https://www.w3.org/"><img width="72" height="48" alt="W3C" src="https://www.w3.org/Icons/w3c_home" /></a> </p>
       <br />
-      <h1 class="title">Open Errata for the RDF-CANON Specification</h1>
+      <h1 class="title">Open Errata for the "RDF Dataset Canonicalization" (RDF-CANON) Specification</h1>
       <dl>
         <dt>Latest errata update:</dt>
         <dd><span id="date"></span></dd>
@@ -33,18 +33,18 @@
 
       <section data-notoc>
         <h1>How to Submit an Erratum?</h1>
-        <p>Errata are introduced and stored in the <a href="https://github.com/w3c/rdf-canon/issues/">issue list of the document‘s GitHub repository</a>. The workflow to add a new erratum is as follows:</p>
-        <ul>
-           <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to “<code>ErratumRaised</code>”. It is o.k. for an erratum to have several labels.</li>
-           <li>Issues labeled as “<code>Editorial</code>” are displayed separately, to make it easier to differentiate editorial errata from substantial ones.</li>
-          <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is added to the entry and the “<code>ErratumRaised</code>” label should be removed. Additionally, a new comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on the discussion).</li>
-          <li>All issues, labeled by “<code>Errata</code>”, are displayed in this report, whether they are opened or closed. Their status is added to the report on the individual errata.</li>
+        <p>Errata are introduced and stored in the <a href="https://github.com/w3c/rdf-canon/issues/">issue list of the document's GitHub repository</a>. The workflow to add a new erratum is as follows:</p>
+        <ol>
+           <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to “<code>ErratumRaised</code>”. It is okay for an erratum to have several labels.</li>
+           <li>Issues labeled as “<code>Editorial</code>” are displayed separately, to make it easier to differentiate editorial errata from substantive ones.</li>
+          <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is added to the entry and the “<code>ErratumRaised</code>” label removed. A new comment on the issue MAY also be added, beginning with the word "Summary:" (if such a summary is useful, based on the discussion).</li>
+          <li>All issues labeled as “<code>Errata</code>” are displayed in this report, whether they are open or closed. Their status is added to the report on the individual errata.</li>
           <li>If the community rejects the issue as an erratum, the issue should be closed.</li>
-          <li>Each errata may be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the substantial ones.</li>
-          <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
-        </ul>
+          <li>Each erratum may be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the substantive ones.</li>
+          <li>ALL substantive errata are expected to have corresponding test(s), in the form of either new tests or modifications to existing tests, or must include a rationale explaining why test updates are not required for the erratum.</li>
+        </ol>
 
-        <p>If you have problems following this process, but you want nevertheless to report an error, you can also contact the staff contact of the Working Group, <a href="mailto:pierre-antoine@w3.org">Pierre-Antoine Champin</a>.</p>
+        <p>If you have problems following this process, but you want nevertheless to report an error, you can contact the staff contact of the Working Group, <a href="mailto:pierre-antoine@w3.org">Pierre-Antoine Champin</a>.</p>
       </section>
     </header>
 
@@ -52,11 +52,11 @@
 
     <main>
       <section data-nolabel>
-        <h1>Open Errata on the “RDF Dataset Canonicalization and Hash” Recommendation</h1>
+        <h1>Open Errata on the "RDF Dataset Canonicalization" (RDF-CANON) Recommendation</h1>
         <dl>
             <dt>Latest Published Version:</dt>
             <dd><a href="https://www.w3.org/TR/rdf-canon/">https://www.w3.org/TR/rdf-canon/</a></dd>
-            <dt>Editor’s draft:</dt>
+            <dt>Editor's draft:</dt>
             <dd><a href="https://w3c.github.io/rdf-canon/spec/">https://w3c.github.io/rdf-canon/spec/</a></dd>
             <dt>Latest Publication Date:</dt>
             <dd class="todo">@@@@ @@@@, @@@@</dd>

--- a/errata/index.html
+++ b/errata/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+  <!--
+    The data-githubrepo attribute provides the owner/repo name on github. For W3C repositories most of those are of the
+    form 'w3c/XXX', although there are groups that have their own owner for their repository.
+  -->
+  <head data-githubrepo="w3c/rdf-canon">
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+    <title>Open Errata for the RDF-CANON specification published by the RCH Working Group</title>
+    <link rel="stylesheet" type="text/css" href="errata.css"/>
+    <script src="https://w3c.github.io/display_errata/assets/errata.js" type="text/javascript"></script>
+    <script src="https://w3c.github.io/display_errata/assets/toc.js" type="text/javascript"></script>
+
+    <style type="text/css">
+      .todo {
+        background-color: yellow
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <p class="banner"><a accesskey="W" href="https://www.w3.org/"><img width="72" height="48" alt="W3C" src="https://www.w3.org/Icons/w3c_home" /></a> </p>
+      <br />
+      <h1 class="title">Open Errata for the RDF-CANON Specification</h1>
+      <dl>
+        <dt>Latest errata update:</dt>
+        <dd><span id="date"></span></dd>
+        <dt>Number of recorded errata:</dt>
+        <dd><span id="number"></span></dd>
+        <dt>Link to all errata:</dt>
+        <dd><span id="errata_link"></span></dd>
+      </dl>
+
+      <section data-notoc>
+        <h1>How to Submit an Erratum?</h1>
+        <p>Errata are introduced and stored in the <a href="https://github.com/w3c/rdf-canon/issues/">issue list of the document‘s GitHub repository</a>. The workflow to add a new erratum is as follows:</p>
+        <ul>
+           <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to “<code>ErratumRaised</code>”. It is o.k. for an erratum to have several labels.</li>
+           <li>Issues labeled as “<code>Editorial</code>” are displayed separately, to make it easier to differentiate editorial errata from substantial ones.</li>
+          <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is added to the entry and the “<code>ErratumRaised</code>” label should be removed. Additionally, a new comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on the discussion).</li>
+          <li>All issues, labeled by “<code>Errata</code>”, are displayed in this report, whether they are opened or closed. Their status is added to the report on the individual errata.</li>
+          <li>If the community rejects the issue as an erratum, the issue should be closed.</li>
+          <li>Each errata may be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the substantial ones.</li>
+          <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
+        </ul>
+
+        <p>If you have problems following this process, but you want nevertheless to report an error, you can also contact the staff contact of the Working Group, <a href="mailto:pierre-antoine@w3.org">Pierre-Antoine Champin</a>.</p>
+      </section>
+    </header>
+
+    <div class="toc" id="toc"></div>
+
+    <main>
+      <section data-nolabel>
+        <h1>Open Errata on the “RDF Dataset Canonicalization and Hash” Recommendation</h1>
+        <dl>
+            <dt>Latest Published Version:</dt>
+            <dd><a href="https://www.w3.org/TR/rdf-canon/">https://www.w3.org/TR/rdf-canon/</a></dd>
+            <dt>Editor’s draft:</dt>
+            <dd><a href="https://w3c.github.io/rdf-canon/spec/">https://w3c.github.io/rdf-canon/spec/</a></dd>
+            <dt>Latest Publication Date:</dt>
+            <dd class="todo">@@@@ @@@@, @@@@</dd>
+        </dl>
+        <section>
+          <h2>Substantial Issues</h2>
+        </section>
+        <section>
+          <h2>Editorial Issues</h2>
+        </section>
+      </section>
+    </main>
+
+    <footer>
+      <address><a href="mailto:pierre-antoine@w3.org" class=''>Pierre-Antoine Champin</a>, pierre-antoine@w3.org, (W3C)</address>
+      <p class="copyright">
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © <span>2024</span> World Wide Web Consortium.
+        W3C® <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, 
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>, and 
+        <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/spec/index.html
+++ b/spec/index.html
@@ -64,6 +64,7 @@
     group: "rch",
     crEnd: "2023-11-28",
     testSuiteURI: "https://w3c.github.io/rdf-canon/tests/",
+    errata: "https://w3c.github.io/rdf-canon/errata/",
     implementationReportURI: "https://w3c.github.io/rdf-canon/reports/",
     xref: ["infra"],
     doJsonLd:     true,


### PR DESCRIPTION
The errata page is required to go to REC.

I'm reusing the infrastructure developed by Ivan, which is the same used by JSON-LD (among others).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/pull/209.html" title="Last updated on May 14, 2024, 2:54 PM UTC (bc88bf4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-canon/209/5f6e38c...bc88bf4.html" title="Last updated on May 14, 2024, 2:54 PM UTC (bc88bf4)">Diff</a>