### PR TITLE
Add youctagh-rdfcanon implementation report 

### DIFF
--- a/reports/youctagh-rdfcanon-earl.ttl
+++ b/reports/youctagh-rdfcanon-earl.ttl
@@ -1,0 +1,1064 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix earl: <http://www.w3.org/ns/earl#> .
+
+<> foaf:primaryTopic <https://github.com/YoucTagh/rdf-canon> ;
+  dc:issued "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  foaf:maker <https://youctagh.github.io/> .
+
+<https://github.com/YoucTagh/rdf-canon> a doap:Project, earl:TestSubject, earl:Software ;
+  doap:name "YoucTagh RDF Canonicalization" ;
+  doap:description "An implementation of RDF Dataset Canonicalization (RDFC 1.0) in Python"@en ;
+  doap:organization <https://team.inria.fr/wimmics> ;
+  doap:developer <https://youctagh.github.io/> ;
+  doap:homepage <https://github.com/YoucTagh/rdf-canon> ;
+  doap:license <https://github.com/YoucTagh/rdf-canon/blob/master/LICENSE> ;
+  doap:release [
+    doap:name "rdfcanon:1.0.0" ;
+    doap:revision "1.0.0" ;
+    doap:created "2025-12-17"^^xsd:date ;
+  ] ;
+  doap:programming-language "Python" .
+
+<https://team.inria.fr/wimmics> a foaf:Organization, earl:Assertor ;
+  foaf:name "Wimmics Team" ;
+  foaf:homepage <https://team.inria.fr/wimmics> .
+
+<https://youctagh.github.io/> a foaf:Person, earl:Assertor ;
+  foaf:name "Yousouf Taghzouti" ;
+  foaf:homepage <https://youctagh.github.io/> .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test001c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test002c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test003c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test003m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test004c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test004m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test005c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test005m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test006c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test008c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test009c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test010c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test011c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test013c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test014c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test016c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test016m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test017c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test017m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test018c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test018m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test019c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test020c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test020m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test021c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test022c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test023c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test024c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test025c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test026c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test027c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test028c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test029c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test030c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test030m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test033c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test034c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test035c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test036c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test038c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test039c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test040c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test043c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test044c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test045c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test046c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test047c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test047m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test048c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test048m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test053c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test053m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test054c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test055c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test055m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test056c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test056m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test057c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test057m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test058c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test059c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:34Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test060c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test060m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test061c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test062c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test063c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test063m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test064c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test065c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test066c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test067c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test068c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test069c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test070c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test070m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test071c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test071m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test072c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test072m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test073c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test073m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:35Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test074c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:38Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test075c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:38Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test075m> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:38Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test076c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:38Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .
+
+[ a earl:Assertion ;
+  earl:assertedBy <https://youctagh.github.io/> ;
+  earl:subject <https://github.com/YoucTagh/rdf-canon> ;
+  earl:test <https://w3c.github.io/rdf-canon/tests/manifest#test077c> ;
+  earl:result [
+    a earl:TestResult ;
+    earl:outcome earl:passed ;
+    dc:date "2025-12-19T09:36:38Z"^^xsd:dateTime ;
+  ] ;
+  earl:mode earl:automatic ;
+] .


### PR DESCRIPTION
Hello,

I've added a new implementation report for RDFC in [Python](https://github.com/YoucTagh/rdf-canon/tree/master). The lib is also on [PyPi](https://pypi.org/project/rdfcanon/).

Please let me know if any further modifications are needed.